### PR TITLE
Relative imports, simplify import aliases and don't import from public API

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,13 +7,13 @@ analyzer:
     - '**/*.swagger.dart'
     - '**/api/proto/**/*.dart'
   errors:
-      invalid_annotation_target: false
+    invalid_annotation_target: false
 
 linter:
   rules:
-    always_use_package_imports: true
     directives_ordering: true
-    prefer_interpolation_to_compose_strings: true
     prefer_final_in_for_each: true
     prefer_final_locals: true
+    prefer_interpolation_to_compose_strings: true
+    prefer_relative_imports: true
     prefer_single_quotes: true

--- a/nakama/example/lib/main.dart
+++ b/nakama/example/lib/main.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:nakama/nakama.dart';
-import 'package:simple_multiplayer_web/widgets/match_area.dart';
-import 'package:simple_multiplayer_web/widgets/matchmaker.dart';
-import 'package:simple_multiplayer_web/widgets/sign_in_box.dart';
-import 'package:simple_multiplayer_web/widgets/welcome.dart';
+
+import 'widgets/match_area.dart';
+import 'widgets/matchmaker.dart';
+import 'widgets/sign_in_box.dart';
+import 'widgets/welcome.dart';
 
 void main() {
   Logger.root.level = Level.ALL;

--- a/nakama/lib/src/models/account.dart
+++ b/nakama/lib/src/models/account.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
+
+import '../api/api.dart' as api;
 
 part 'account.freezed.dart';
 part 'account.g.dart';

--- a/nakama/lib/src/models/channel_message.dart
+++ b/nakama/lib/src/models/channel_message.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
+
+import '../api/api.dart' as api;
 
 part 'channel_message.freezed.dart';
 part 'channel_message.g.dart';

--- a/nakama/lib/src/models/chat.dart
+++ b/nakama/lib/src/models/chat.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
+
+import '../api/rtapi.dart' as rtapi;
+import 'status.dart';
 
 part 'chat.freezed.dart';
 
@@ -35,7 +36,7 @@ class Channel with _$Channel {
     @JsonKey(name: 'user_id_two') required String userIdTwo,
   }) = _Channel;
 
-  factory Channel.fromDto(rtpb.Channel dto) => Channel(
+  factory Channel.fromDto(rtapi.Channel dto) => Channel(
         id: dto.id,
         presences: dto.presences
             .map((e) => UserPresence.fromDto(e))
@@ -89,7 +90,7 @@ class ChannelMessageAck with _$ChannelMessageAck {
     @JsonKey(name: 'user_id_two') required String userIdTwo,
   }) = _ChannelMessageAck;
 
-  factory ChannelMessageAck.fromDto(rtpb.ChannelMessageAck dto) =>
+  factory ChannelMessageAck.fromDto(rtapi.ChannelMessageAck dto) =>
       ChannelMessageAck(
         channelId: dto.channelId,
         messageId: dto.messageId,

--- a/nakama/lib/src/models/friends.dart
+++ b/nakama/lib/src/models/friends.dart
@@ -1,7 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/enum/friendship_state.dart';
-import 'package:nakama/src/models/account.dart';
+
+import '../api/api.dart' as api;
+import '../enum/friendship_state.dart';
+import 'account.dart';
 
 part 'friends.freezed.dart';
 part 'friends.g.dart';

--- a/nakama/lib/src/models/group.dart
+++ b/nakama/lib/src/models/group.dart
@@ -1,7 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/enum/group_membership_states.dart';
-import 'package:nakama/src/models/account.dart';
+
+import '../api/api.dart' as api;
+import '../enum/group_membership_states.dart';
+import 'account.dart';
 
 part 'group.freezed.dart';
 part 'group.g.dart';

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
+
+import '../api/api.dart' as api;
 
 part 'leaderboard.freezed.dart';
 part 'leaderboard.g.dart';

--- a/nakama/lib/src/models/match.dart
+++ b/nakama/lib/src/models/match.dart
@@ -1,7 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
+
+import '../api/api.dart' as api;
+import '../api/rtapi.dart' as rtapi;
+import 'status.dart';
 
 part 'match.freezed.dart';
 part 'match.g.dart';
@@ -42,7 +43,7 @@ class Match with _$Match {
         presences: [],
       );
 
-  factory Match.fromRtpb(rtpb.Match dto) => Match.realtime(
+  factory Match.fromRtpb(rtapi.Match dto) => Match.realtime(
         matchId: dto.matchId,
         authoritative: dto.authoritative,
         label: dto.label.value,
@@ -77,7 +78,7 @@ class Party with _$Party {
     @JsonKey(name: 'presences') required List<UserPresence> presences,
   }) = _Party;
 
-  factory Party.fromDto(rtpb.Party dto) => Party(
+  factory Party.fromDto(rtapi.Party dto) => Party(
         partyId: dto.partyId,
         open: dto.open,
         maxSize: dto.maxSize,

--- a/nakama/lib/src/models/match.dart
+++ b/nakama/lib/src/models/match.dart
@@ -43,7 +43,7 @@ class Match with _$Match {
         presences: [],
       );
 
-  factory Match.fromRtpb(rtapi.Match dto) => Match.realtime(
+  factory Match.fromRtDto(rtapi.Match dto) => Match.realtime(
         matchId: dto.matchId,
         authoritative: dto.authoritative,
         label: dto.label.value,

--- a/nakama/lib/src/models/matchmaker.dart
+++ b/nakama/lib/src/models/matchmaker.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
+
+import '../api/rtapi.dart' as rtapi;
+import 'status.dart';
 
 part 'matchmaker.freezed.dart';
 
@@ -13,7 +14,7 @@ class MatchmakerTicket with _$MatchmakerTicket {
     required String ticket,
   }) = _MatchmakerTicket;
 
-  factory MatchmakerTicket.fromDto(rtpb.MatchmakerTicket dto) =>
+  factory MatchmakerTicket.fromDto(rtapi.MatchmakerTicket dto) =>
       MatchmakerTicket(
         ticket: dto.ticket,
       );
@@ -31,7 +32,7 @@ class PartyMatchmakerTicket with _$PartyMatchmakerTicket {
     @JsonKey(name: 'ticket') required String ticket,
   }) = _PartyMatchmakerTicket;
 
-  factory PartyMatchmakerTicket.fromDto(rtpb.PartyMatchmakerTicket dto) =>
+  factory PartyMatchmakerTicket.fromDto(rtapi.PartyMatchmakerTicket dto) =>
       PartyMatchmakerTicket(
         partyId: dto.partyId,
         ticket: dto.ticket,
@@ -69,7 +70,7 @@ class ChannelPresenceEvent with _$ChannelPresenceEvent {
     @JsonKey(name: 'user_id_two') String? userIdTwo,
   }) = _ChannelPresenceEvent;
 
-  factory ChannelPresenceEvent.fromDto(rtpb.ChannelPresenceEvent dto) =>
+  factory ChannelPresenceEvent.fromDto(rtapi.ChannelPresenceEvent dto) =>
       ChannelPresenceEvent(
         channelId: dto.channelId,
         roomName: dto.roomName,
@@ -105,7 +106,7 @@ class MatchmakerUser with _$MatchmakerUser {
     required Map<String, double> numericProperties,
   }) = _MatchmakerUser;
 
-  factory MatchmakerUser.fromDto(rtpb.MatchmakerMatched_MatchmakerUser dto) =>
+  factory MatchmakerUser.fromDto(rtapi.MatchmakerMatched_MatchmakerUser dto) =>
       MatchmakerUser(
         presence: UserPresence.fromDto(dto.presence),
         partyId: dto.partyId,
@@ -135,7 +136,7 @@ class MatchmakerMatched with _$MatchmakerMatched {
     @JsonKey(name: 'self') required MatchmakerUser self,
   }) = _MatchmakerMatched;
 
-  factory MatchmakerMatched.fromDto(rtpb.MatchmakerMatched dto) =>
+  factory MatchmakerMatched.fromDto(rtapi.MatchmakerMatched dto) =>
       MatchmakerMatched(
         ticket: dto.ticket,
         matchId: dto.matchId,
@@ -168,7 +169,7 @@ class MatchData with _$MatchData {
     @JsonKey(name: 'reliable') required bool reliable,
   }) = _MatchData;
 
-  factory MatchData.fromDto(rtpb.MatchData dto) => MatchData(
+  factory MatchData.fromDto(rtapi.MatchData dto) => MatchData(
         matchId: dto.matchId,
         presence: UserPresence.fromDto(dto.presence),
         opCode: dto.opCode.toInt(),
@@ -192,7 +193,7 @@ class MatchPresenceEvent with _$MatchPresenceEvent {
     @JsonKey(name: 'leaves') required List<UserPresence> leaves,
   }) = _MatchPresenceEvent;
 
-  factory MatchPresenceEvent.fromDto(rtpb.MatchPresenceEvent dto) =>
+  factory MatchPresenceEvent.fromDto(rtapi.MatchPresenceEvent dto) =>
       MatchPresenceEvent(
         matchId: dto.matchId,
         joins: dto.joins

--- a/nakama/lib/src/models/notification.dart
+++ b/nakama/lib/src/models/notification.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
+
+import '../api/api.dart' as api;
 
 part 'notification.freezed.dart';
 part 'notification.g.dart';

--- a/nakama/lib/src/models/party.dart
+++ b/nakama/lib/src/models/party.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
+
+import '../api/rtapi.dart' as rtapi;
+import 'status.dart';
 
 part 'party.freezed.dart';
 
@@ -22,7 +23,7 @@ class PartyData with _$PartyData {
     @JsonKey(name: 'data') List<int>? data,
   }) = _PartyData;
 
-  factory PartyData.fromDto(rtpb.PartyData dto) => PartyData(
+  factory PartyData.fromDto(rtapi.PartyData dto) => PartyData(
         partyId: dto.partyId,
         presence: UserPresence.fromDto(dto.presence),
         opCode: dto.opCode.toInt(),
@@ -45,7 +46,7 @@ class PartyPresenceEvent with _$PartyPresenceEvent {
     @JsonKey(name: 'leaves') List<UserPresence>? leaves,
   }) = _PartyPresenceEvent;
 
-  factory PartyPresenceEvent.fromDto(rtpb.PartyPresenceEvent dto) =>
+  factory PartyPresenceEvent.fromDto(rtapi.PartyPresenceEvent dto) =>
       PartyPresenceEvent(
         partyId: dto.partyId,
         joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(),
@@ -65,7 +66,7 @@ class PartyLeader with _$PartyLeader {
     @JsonKey(name: 'presence') UserPresence? newLeader,
   }) = _PartyLeader;
 
-  factory PartyLeader.fromDto(rtpb.PartyLeader dto) => PartyLeader(
+  factory PartyLeader.fromDto(rtapi.PartyLeader dto) => PartyLeader(
         partyId: dto.partyId,
         newLeader: UserPresence.fromDto(dto.presence),
       );

--- a/nakama/lib/src/models/rpc.dart
+++ b/nakama/lib/src/models/rpc.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
+
+import '../api/api.dart' as api;
 
 part 'rpc.freezed.dart';
 

--- a/nakama/lib/src/models/session.dart
+++ b/nakama/lib/src/models/session.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 
-import '../api/api.dart' as dto;
+import '../api/api.dart' as api;
 import '../rest/api_client.gen.dart';
 
 part 'session.freezed.dart';
@@ -20,7 +20,7 @@ class Session with _$Session {
     required DateTime refreshExpiresAt,
   }) = _Session;
 
-  factory Session.fromDto(dto.Session session) {
+  factory Session.fromDto(api.Session session) {
     final token = JwtDecoder.decode(session.token);
     assert(token.containsKey('uid'));
 

--- a/nakama/lib/src/models/session.dart
+++ b/nakama/lib/src/models/session.dart
@@ -1,7 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
-import 'package:nakama/src/api/api.dart' as dto;
-import 'package:nakama/src/rest/api_client.gen.dart';
+
+import '../api/api.dart' as dto;
+import '../rest/api_client.gen.dart';
 
 part 'session.freezed.dart';
 

--- a/nakama/lib/src/models/status.dart
+++ b/nakama/lib/src/models/status.dart
@@ -107,7 +107,8 @@ class RealtimeStreamData with _$RealtimeStreamData {
     required bool reliable,
   }) = _RealtimeStreamData;
 
-  factory RealtimeStreamData.fromDto(rtapi.StreamData dto) => RealtimeStreamData(
+  factory RealtimeStreamData.fromDto(rtapi.StreamData dto) =>
+      RealtimeStreamData(
         stream: RealtimeStream.fromDto(dto.stream),
         sender: UserPresence.fromDto(dto.sender),
         data: dto.data,

--- a/nakama/lib/src/models/status.dart
+++ b/nakama/lib/src/models/status.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
+
+import '../api/rtapi.dart' as rtapi;
 
 part 'status.freezed.dart';
 part 'status.g.dart';
@@ -27,7 +28,7 @@ class UserPresence with _$UserPresence {
     @JsonKey(name: 'status') String? status,
   }) = _UserPresence;
 
-  factory UserPresence.fromDto(rtpb.UserPresence dto) => UserPresence(
+  factory UserPresence.fromDto(rtapi.UserPresence dto) => UserPresence(
         userId: dto.userId,
         sessionId: dto.sessionId,
         username: dto.username,
@@ -51,7 +52,7 @@ class StatusPresenceEvent with _$StatusPresenceEvent {
     required List<UserPresence> leaves,
   }) = _StatusPresenceEvent;
 
-  factory StatusPresenceEvent.fromDto(rtpb.StatusPresenceEvent dto) =>
+  factory StatusPresenceEvent.fromDto(rtapi.StatusPresenceEvent dto) =>
       StatusPresenceEvent(
         joins: dto.joins
             .map((e) => UserPresence.fromDto(e))
@@ -80,7 +81,7 @@ class RealtimeStream with _$RealtimeStream {
     required String label,
   }) = _RealtimeStream;
 
-  factory RealtimeStream.fromDto(rtpb.Stream dto) => RealtimeStream(
+  factory RealtimeStream.fromDto(rtapi.Stream dto) => RealtimeStream(
         mode: dto.mode,
         subject: dto.subject,
         subcontext: dto.subcontext,
@@ -106,7 +107,7 @@ class RealtimeStreamData with _$RealtimeStreamData {
     required bool reliable,
   }) = _RealtimeStreamData;
 
-  factory RealtimeStreamData.fromDto(rtpb.StreamData dto) => RealtimeStreamData(
+  factory RealtimeStreamData.fromDto(rtapi.StreamData dto) => RealtimeStreamData(
         stream: RealtimeStream.fromDto(dto.stream),
         sender: UserPresence.fromDto(dto.sender),
         data: dto.data,
@@ -129,7 +130,7 @@ class StreamPresenceEvent with _$StreamPresenceEvent {
     required List<UserPresence> leaves,
   }) = _StreamPresenceEvent;
 
-  factory StreamPresenceEvent.fromDto(rtpb.StreamPresenceEvent dto) =>
+  factory StreamPresenceEvent.fromDto(rtapi.StreamPresenceEvent dto) =>
       StreamPresenceEvent(
         stream: RealtimeStream.fromDto(dto.stream),
         joins: dto.joins

--- a/nakama/lib/src/models/storage.dart
+++ b/nakama/lib/src/models/storage.dart
@@ -1,7 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/api/proto/google/protobuf/wrappers.pb.dart';
-import 'package:nakama/src/enum/storage_permission.dart';
+
+import '../api/api.dart' as api;
+import '../api/proto/google/protobuf/wrappers.pb.dart';
+import '../enum/storage_permission.dart';
 
 part 'storage.freezed.dart';
 part 'storage.g.dart';

--- a/nakama/lib/src/models/tournament.dart
+++ b/nakama/lib/src/models/tournament.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/models/leaderboard.dart';
+
+import '../api/api.dart' as api;
+import 'leaderboard.dart';
 
 part 'tournament.freezed.dart';
 part 'tournament.g.dart';

--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -2,19 +2,19 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
-import '../enum/friendship_state.dart' as model;
-import '../enum/group_membership_states.dart' as model;
-import '../models/account.dart' as model;
-import '../models/channel_message.dart' as model;
-import '../models/friends.dart' as model;
-import '../models/group.dart' as model;
-import '../models/leaderboard.dart' as model;
-import '../models/match.dart' as model;
-import '../models/notification.dart' as model;
+import '../enum/friendship_state.dart';
+import '../enum/group_membership_states.dart';
+import '../models/account.dart';
+import '../models/channel_message.dart';
+import '../models/friends.dart';
+import '../models/group.dart';
+import '../models/leaderboard.dart';
+import '../models/match.dart';
+import '../models/notification.dart';
 import '../models/response_error.dart';
-import '../models/session.dart' as model;
-import '../models/storage.dart' as model;
-import '../models/tournament.dart' as model;
+import '../models/session.dart';
+import '../models/storage.dart';
+import '../models/tournament.dart';
 import '../rest/api_client.gen.dart';
 import 'nakama_client.dart';
 
@@ -36,7 +36,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   /// Temporarily holds the current valid session to use in the Chopper
   /// interceptor for JWT auth.
-  model.Session? _session;
+  Session? _session;
 
   /// Either inits and returns a new instance of [NakamaRestApiClient] or
   /// returns a already initialized one.
@@ -117,8 +117,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> sessionRefresh({
-    required model.Session session,
+  Future<Session> sessionRefresh({
+    required Session session,
     Map<String, String>? vars,
   }) async {
     if (session.refreshToken == null) {
@@ -132,14 +132,14 @@ class NakamaRestApiClient extends NakamaBaseClient {
           vars: vars,
         ),
       );
-      return model.Session.fromApi(newSession);
+      return Session.fromApi(newSession);
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<void> sessionLogout({required model.Session session}) async {
+  Future<void> sessionLogout({required Session session}) async {
     _session = session;
     try {
       await _api.sessionLogout(
@@ -154,7 +154,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateEmail({
+  Future<Session> authenticateEmail({
     String? email,
     String? username,
     required String password,
@@ -171,7 +171,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         ),
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -179,7 +179,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -199,7 +199,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -218,7 +218,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateDevice({
+  Future<Session> authenticateDevice({
     required String deviceId,
     bool create = true,
     String? username,
@@ -232,7 +232,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -240,7 +240,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   }) async {
@@ -255,7 +255,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   }) async {
@@ -269,7 +269,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateFacebook({
+  Future<Session> authenticateFacebook({
     required String token,
     bool create = true,
     String? username,
@@ -288,7 +288,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -296,7 +296,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     bool import = false,
     Map<String, String>? vars,
@@ -316,7 +316,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -333,7 +333,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateGoogle({
+  Future<Session> authenticateGoogle({
     required String token,
     bool create = true,
     String? username,
@@ -350,7 +350,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -358,7 +358,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -376,7 +376,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -393,7 +393,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateApple({
+  Future<Session> authenticateApple({
     required String token,
     bool create = true,
     String? username,
@@ -410,7 +410,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -418,7 +418,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -436,7 +436,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -453,7 +453,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateFacebookInstantGame({
+  Future<Session> authenticateFacebookInstantGame({
     required String signedPlayerInfo,
     bool create = true,
     String? username,
@@ -470,7 +470,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -478,7 +478,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   }) async {
@@ -496,7 +496,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   }) async {
@@ -513,7 +513,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateGameCenter({
+  Future<Session> authenticateGameCenter({
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -540,7 +540,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -548,7 +548,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -576,7 +576,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -603,7 +603,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateSteam({
+  Future<Session> authenticateSteam({
     required String token,
     bool create = true,
     String? username,
@@ -619,7 +619,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         username: username,
         sync: import,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -627,7 +627,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -646,7 +646,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -661,7 +661,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateCustom({
+  Future<Session> authenticateCustom({
     required String id,
     bool create = true,
     String? username,
@@ -673,7 +673,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         create: create,
         username: username,
       );
-      return model.Session.fromApi(session);
+      return Session.fromApi(session);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -681,7 +681,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> linkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   }) async {
@@ -696,7 +696,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   }) async {
@@ -711,7 +711,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> importFacebookFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,
@@ -733,7 +733,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> importSteamFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,
@@ -751,13 +751,13 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Account> getAccount(model.Session session) async {
+  Future<Account> getAccount(Session session) async {
     _session = session;
 
     try {
       final account = await _api.getAccount();
 
-      return model.Account.fromJson(account.toJson());
+      return Account.fromJson(account.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -765,7 +765,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> updateAccount({
-    required model.Session session,
+    required Session session,
     String? username,
     String? displayName,
     String? avatarUrl,
@@ -792,8 +792,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<List<model.User>> getUsers({
-    required model.Session session,
+  Future<List<User>> getUsers({
+    required Session session,
     List<String>? facebookIds,
     required List<String> ids,
     List<String>? usernames,
@@ -807,7 +807,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
       );
 
       return users.users
-              ?.map((e) => model.User.fromJson(e.toJson()))
+              ?.map((e) => User.fromJson(e.toJson()))
               .toList(growable: false) ??
           [];
     } on Exception catch (e) {
@@ -817,8 +817,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> writeStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectWrite> objects,
+    required Session session,
+    required Iterable<StorageObjectWrite> objects,
   }) async {
     _session = session;
 
@@ -843,8 +843,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.StorageObjectList> listStorageObjects({
-    required model.Session session,
+  Future<StorageObjectList> listStorageObjects({
+    required Session session,
     required String collection,
     String? cursor,
     String? userId,
@@ -860,16 +860,16 @@ class NakamaRestApiClient extends NakamaBaseClient {
         cursor: cursor,
       );
 
-      return model.StorageObjectList.fromJson(objects.toJson());
+      return StorageObjectList.fromJson(objects.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<List<model.StorageObject>> readStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+  Future<List<StorageObject>> readStorageObjects({
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   }) async {
     _session = session;
 
@@ -887,7 +887,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
       );
 
       return objects.objects
-              ?.map((e) => model.StorageObject.fromJson(e.toJson()))
+              ?.map((e) => StorageObject.fromJson(e.toJson()))
               .toList(growable: false) ??
           [];
     } on Exception catch (e) {
@@ -897,8 +897,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   }) async {
     _session = session;
 
@@ -920,8 +920,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.ChannelMessageList> listChannelMessages({
-    required model.Session session,
+  Future<ChannelMessageList> listChannelMessages({
+    required Session session,
     required String channelId,
     int limit = defaultLimit,
     bool? forward,
@@ -937,15 +937,15 @@ class NakamaRestApiClient extends NakamaBaseClient {
         cursor: cursor,
       );
 
-      return model.ChannelMessageList.fromJson(res.toJson());
+      return ChannelMessageList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.LeaderboardRecordList> listLeaderboardRecords({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecords({
+    required Session session,
     required String leaderboardName,
     List<String>? ownerIds,
     int limit = defaultLimit,
@@ -965,15 +965,15 @@ class NakamaRestApiClient extends NakamaBaseClient {
             : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
       );
 
-      return model.LeaderboardRecordList.fromJson(res.toJson());
+      return LeaderboardRecordList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
+    required Session session,
     required String leaderboardName,
     required String ownerId,
     int limit = defaultLimit,
@@ -991,20 +991,20 @@ class NakamaRestApiClient extends NakamaBaseClient {
             : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
       );
 
-      return model.LeaderboardRecordList.fromJson(res.toJson());
+      return LeaderboardRecordList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.LeaderboardRecord> writeLeaderboardRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeLeaderboardRecord({
+    required Session session,
     required String leaderboardName,
     required int score,
     int? subscore,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
   }) async {
     _session = session;
 
@@ -1018,7 +1018,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
             operator: ApiOperator.values[operator?.index ?? 0],
           ));
 
-      return model.LeaderboardRecord.fromJson(res.toJson());
+      return LeaderboardRecord.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1026,7 +1026,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteLeaderboardRecord({
-    required model.Session session,
+    required Session session,
     required String leaderboardName,
   }) async {
     _session = session;
@@ -1040,7 +1040,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> addFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   }) async {
@@ -1054,9 +1054,9 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.FriendsList> listFriends({
-    required model.Session session,
-    model.FriendshipState? friendshipState,
+  Future<FriendsList> listFriends({
+    required Session session,
+    FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -1069,7 +1069,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         state: friendshipState?.index,
       );
 
-      return model.FriendsList.fromJson(res.toJson());
+      return FriendsList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1077,7 +1077,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   }) async {
@@ -1095,7 +1095,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> blockFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   }) async {
@@ -1112,8 +1112,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Group> createGroup({
-    required model.Session session,
+  Future<Group> createGroup({
+    required Session session,
     required String name,
     String? avatarUrl,
     String? description,
@@ -1135,7 +1135,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         ),
       );
 
-      return model.Group.fromJson(res.toJson());
+      return Group.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1143,7 +1143,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> updateGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
     String? name,
     String? avatarUrl,
@@ -1172,8 +1172,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.GroupList> listGroups({
-    required model.Session session,
+  Future<GroupList> listGroups({
+    required Session session,
     String? name,
     String? cursor,
     String? langTag,
@@ -1193,7 +1193,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         open: open,
       );
 
-      return model.GroupList.fromJson(res.toJson());
+      return GroupList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1201,7 +1201,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     _session = session;
@@ -1215,7 +1215,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> joinGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     _session = session;
@@ -1228,11 +1228,11 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.UserGroupList> listUserGroups({
-    required model.Session session,
+  Future<UserGroupList> listUserGroups({
+    required Session session,
     String? cursor,
     int limit = defaultLimit,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
     String? userId,
   }) async {
     _session = session;
@@ -1245,19 +1245,19 @@ class NakamaRestApiClient extends NakamaBaseClient {
         userId: userId ?? session.userId,
       );
 
-      return model.UserGroupList.fromJson(res.toJson());
+      return UserGroupList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.GroupUserList> listGroupUsers({
-    required model.Session session,
+  Future<GroupUserList> listGroupUsers({
+    required Session session,
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
   }) async {
     _session = session;
 
@@ -1269,7 +1269,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         state: state?.index,
       );
 
-      return model.GroupUserList.fromJson(res.toJson());
+      return GroupUserList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1277,7 +1277,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> addGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1295,7 +1295,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> promoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1313,7 +1313,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> demoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1331,7 +1331,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> kickGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1349,7 +1349,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> banGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1367,7 +1367,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> leaveGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     _session = session;
@@ -1380,8 +1380,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.NotificationList> listNotifications({
-    required model.Session session,
+  Future<NotificationList> listNotifications({
+    required Session session,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -1393,7 +1393,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         cacheableCursor: cursor,
       );
 
-      return model.NotificationList.fromJson(res.toJson());
+      return NotificationList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1401,7 +1401,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteNotifications({
-    required model.Session session,
+    required Session session,
     required Iterable<String> notificationIds,
   }) async {
     _session = session;
@@ -1416,8 +1416,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<List<model.Match>> listMatches({
-    required model.Session session,
+  Future<List<Match>> listMatches({
+    required Session session,
     bool? authoritative,
     String? label,
     int limit = defaultLimit,
@@ -1438,7 +1438,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
       );
 
       return res.matches
-              ?.map((e) => model.Match.fromJson(e.toJson()))
+              ?.map((e) => Match.fromJson(e.toJson()))
               .toList(growable: false) ??
           [];
     } on Exception catch (e) {
@@ -1448,7 +1448,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<void> joinTournament({
-    required model.Session session,
+    required Session session,
     required String tournamentId,
   }) async {
     _session = session;
@@ -1461,8 +1461,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.TournamentList> listTournaments({
-    required model.Session session,
+  Future<TournamentList> listTournaments({
+    required Session session,
     int? categoryStart,
     int? categoryEnd,
     String? cursor,
@@ -1484,15 +1484,15 @@ class NakamaRestApiClient extends NakamaBaseClient {
         limit: limit,
       );
 
-      return model.TournamentList.fromJson(res.toJson());
+      return TournamentList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.TournamentRecordList> listTournamentRecords({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecords({
+    required Session session,
     required String tournamentId,
     required Iterable<String> ownerIds,
     int? expiry,
@@ -1510,15 +1510,15 @@ class NakamaRestApiClient extends NakamaBaseClient {
         limit: limit,
       );
 
-      return model.TournamentRecordList.fromJson(res.toJson());
+      return TournamentRecordList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.TournamentRecordList> listTournamentRecordsAroundOwner({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecordsAroundOwner({
+    required Session session,
     required String tournamentId,
     required String ownerId,
     int? expiry,
@@ -1534,18 +1534,18 @@ class NakamaRestApiClient extends NakamaBaseClient {
         limit: limit,
       );
 
-      return model.TournamentRecordList.fromJson(res.toJson());
+      return TournamentRecordList.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
   }
 
   @override
-  Future<model.LeaderboardRecord> writeTournamentRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeTournamentRecord({
+    required Session session,
     required String tournamentId,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
     int? score,
     int? subscore,
   }) async {
@@ -1562,7 +1562,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
         ),
       );
 
-      return model.LeaderboardRecord.fromJson(res.toJson());
+      return LeaderboardRecord.fromJson(res.toJson());
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1570,7 +1570,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<String?> rpc({
-    required model.Session session,
+    required Session session,
     required String id,
     String? payload,
   }) async {

--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -1,19 +1,22 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/models/account.dart' as model;
-import 'package:nakama/src/models/channel_message.dart' as model;
-import 'package:nakama/src/models/friends.dart' as model;
-import 'package:nakama/src/models/group.dart' as model;
-import 'package:nakama/src/models/leaderboard.dart' as model;
-import 'package:nakama/src/models/match.dart' as model;
-import 'package:nakama/src/models/notification.dart' as model;
-import 'package:nakama/src/models/response_error.dart';
-import 'package:nakama/src/models/session.dart' as model;
-import 'package:nakama/src/models/storage.dart' as model;
-import 'package:nakama/src/models/tournament.dart' as model;
-import 'package:nakama/src/rest/api_client.gen.dart';
+
+import '../enum/friendship_state.dart' as model;
+import '../enum/group_membership_states.dart' as model;
+import '../models/account.dart' as model;
+import '../models/channel_message.dart' as model;
+import '../models/friends.dart' as model;
+import '../models/group.dart' as model;
+import '../models/leaderboard.dart' as model;
+import '../models/match.dart' as model;
+import '../models/notification.dart' as model;
+import '../models/response_error.dart';
+import '../models/session.dart' as model;
+import '../models/storage.dart' as model;
+import '../models/tournament.dart' as model;
+import '../rest/api_client.gen.dart';
+import 'nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
 
@@ -1001,7 +1004,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required int score,
     int? subscore,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
   }) async {
     _session = session;
 
@@ -1053,7 +1056,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   @override
   Future<model.FriendsList> listFriends({
     required model.Session session,
-    FriendshipState? friendshipState,
+    model.FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -1229,7 +1232,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required model.Session session,
     String? cursor,
     int limit = defaultLimit,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
     String? userId,
   }) async {
     _session = session;
@@ -1254,7 +1257,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
   }) async {
     _session = session;
 
@@ -1542,7 +1545,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required model.Session session,
     required String tournamentId,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
     int? score,
     int? subscore,
   }) async {

--- a/nakama/lib/src/nakama_client/nakama_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_client.dart
@@ -1,15 +1,15 @@
-import '../enum/friendship_state.dart' as model;
-import '../enum/group_membership_states.dart' as model;
-import '../models/account.dart' as model;
-import '../models/channel_message.dart' as model;
-import '../models/friends.dart' as model;
-import '../models/group.dart' as model;
-import '../models/leaderboard.dart' as model;
-import '../models/match.dart' as model;
-import '../models/notification.dart' as model;
-import '../models/session.dart' as model;
-import '../models/storage.dart' as model;
-import '../models/tournament.dart' as model;
+import '../enum/friendship_state.dart';
+import '../enum/group_membership_states.dart';
+import '../models/account.dart';
+import '../models/channel_message.dart';
+import '../models/friends.dart';
+import '../models/group.dart';
+import '../models/leaderboard.dart';
+import '../models/match.dart';
+import '../models/notification.dart';
+import '../models/session.dart';
+import '../models/storage.dart';
+import '../models/tournament.dart';
 
 const _kDefaultAppKey = 'default';
 const defaultLimit = 20;
@@ -34,15 +34,15 @@ abstract class NakamaBaseClient {
   ///
   /// - [session] Current session.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> sessionRefresh({
-    required model.Session session,
+  Future<Session> sessionRefresh({
+    required Session session,
     Map<String, String>? vars,
   });
 
   /// Logout user session and invalidate refresh token.
   ///
   /// - [session] The session to log out.
-  Future<void> sessionLogout({required model.Session session});
+  Future<void> sessionLogout({required Session session});
 
   /// Authenticate a user with an email and password.
   ///
@@ -51,7 +51,7 @@ abstract class NakamaBaseClient {
   /// - [password] The password for the user.
   /// - [create] If the user should be created when authenticated.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateEmail({
+  Future<Session> authenticateEmail({
     String? email,
     String? username,
     required String password,
@@ -66,7 +66,7 @@ abstract class NakamaBaseClient {
   /// - [password] The password for the user.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> linkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -79,7 +79,7 @@ abstract class NakamaBaseClient {
   /// - [password] The password for the user to remove.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -91,7 +91,7 @@ abstract class NakamaBaseClient {
   /// - [create] If the user should be created when authenticated.
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateDevice({
+  Future<Session> authenticateDevice({
     required String deviceId,
     bool create = false,
     String? username,
@@ -104,13 +104,13 @@ abstract class NakamaBaseClient {
   /// - [deviceId] A device identifier usually obtained from a platform API.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> linkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   });
 
   Future<void> unlinkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   });
@@ -122,7 +122,7 @@ abstract class NakamaBaseClient {
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
   /// - [import] If the Facebook friends should be imported.
-  Future<model.Session> authenticateFacebook({
+  Future<Session> authenticateFacebook({
     required String token,
     bool create = true,
     String? username,
@@ -137,7 +137,7 @@ abstract class NakamaBaseClient {
   /// [import] If the Facebook friends should be imported.
   /// [vars] Extra information that will be bundled in the session token.
   Future<void> linkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     bool import = false,
     Map<String, String>? vars,
@@ -149,7 +149,7 @@ abstract class NakamaBaseClient {
   /// [token] An OAuth access token from the Facebook SDK.
   /// [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   });
@@ -160,7 +160,7 @@ abstract class NakamaBaseClient {
   /// - [create] If the user should be created when authenticated.
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateGoogle({
+  Future<Session> authenticateGoogle({
     required String token,
     bool create = true,
     String? username,
@@ -173,7 +173,7 @@ abstract class NakamaBaseClient {
   /// - [token] An OAuth access token from the Google SDK.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> linkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   });
@@ -184,7 +184,7 @@ abstract class NakamaBaseClient {
   /// - [token] An OAuth access token from the Google SDK.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   });
@@ -195,7 +195,7 @@ abstract class NakamaBaseClient {
   /// [create] If the user should be created when authenticated.
   /// [username] A username used to create the user.
   /// [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateApple({
+  Future<Session> authenticateApple({
     required String token,
     bool create = true,
     String? username,
@@ -208,7 +208,7 @@ abstract class NakamaBaseClient {
   /// [token] An authentication token from the Apple network.
   /// [vars] Extra information that will be bundled in the session token.
   Future<void> linkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   });
@@ -219,12 +219,12 @@ abstract class NakamaBaseClient {
   /// [token] The ID token received from Apple to validate.
   /// [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   });
 
-  Future<model.Session> authenticateFacebookInstantGame({
+  Future<Session> authenticateFacebookInstantGame({
     required String signedPlayerInfo,
     bool create = true,
     String? username,
@@ -232,13 +232,13 @@ abstract class NakamaBaseClient {
   });
 
   Future<void> linkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   });
 
   Future<void> unlinkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   });
@@ -254,7 +254,7 @@ abstract class NakamaBaseClient {
   /// - [create] If the user should be created when authenticated.
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateGameCenter({
+  Future<Session> authenticateGameCenter({
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -277,7 +277,7 @@ abstract class NakamaBaseClient {
   /// - [publicKeyUrl] The URL for the public encryption key.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> linkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -298,7 +298,7 @@ abstract class NakamaBaseClient {
   /// - [publicKeyUrl] The URL for the public encryption key.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -315,7 +315,7 @@ abstract class NakamaBaseClient {
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
   /// - [import] If the Steam friends should be imported.
-  Future<model.Session> authenticateSteam({
+  Future<Session> authenticateSteam({
     required String token,
     bool create = true,
     String? username,
@@ -330,7 +330,7 @@ abstract class NakamaBaseClient {
   /// - [vars] Extra information that will be bundled in the session token.
   /// - [import] If the Steam friends should be imported.
   Future<void> linkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -343,7 +343,7 @@ abstract class NakamaBaseClient {
   /// - [vars] Extra information that will be bundled in the session token.
   /// - [import] If the Steam friends should be imported.
   Future<void> unlinkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -355,7 +355,7 @@ abstract class NakamaBaseClient {
   /// - [create] If the user should be created when authenticated.
   /// - [username] A username used to create the user.
   /// - [vars] Extra information that will be bundled in the session token.
-  Future<model.Session> authenticateCustom({
+  Future<Session> authenticateCustom({
     required String id,
     bool create = true,
     String? username,
@@ -368,7 +368,7 @@ abstract class NakamaBaseClient {
   /// - [id] A custom identifier usually obtained from an external authentication service.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> linkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   });
@@ -379,7 +379,7 @@ abstract class NakamaBaseClient {
   /// - [id] A custom identifier usually obtained from an external authentication service.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> unlinkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   });
@@ -393,7 +393,7 @@ abstract class NakamaBaseClient {
   /// - [reset] If the Facebook friend import for the user should be reset.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> importFacebookFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,
@@ -408,7 +408,7 @@ abstract class NakamaBaseClient {
   /// - [reset] If the Steam friend import for the user should be reset.
   /// - [vars] Extra information that will be bundled in the session token.
   Future<void> importSteamFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,
@@ -417,7 +417,7 @@ abstract class NakamaBaseClient {
   /// Fetch the user account owned by the session.
   ///
   /// [session] Current session.
-  Future<model.Account> getAccount(model.Session session);
+  Future<Account> getAccount(Session session);
 
   /// Update the current user's account on the server.
   ///
@@ -429,7 +429,7 @@ abstract class NakamaBaseClient {
   /// [location] A new location for the user.
   /// [timezone] New timezone information for the user.
   Future<void> updateAccount({
-    required model.Session session,
+    required Session session,
     String? username,
     String? displayName,
     String? avatarUrl,
@@ -444,8 +444,8 @@ abstract class NakamaBaseClient {
   /// - [ids] The IDs of the users to retrieve.
   /// - [usernames] The usernames of the users to retrieve.
   /// - [facebookIds] The Facebook IDs of the users to retrieve.
-  Future<List<model.User>> getUsers({
-    required model.Session session,
+  Future<List<User>> getUsers({
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
     List<String>? facebookIds,
@@ -456,8 +456,8 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [objects] The objects to write.
   Future<void> writeStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectWrite> objects,
+    required Session session,
+    required Iterable<StorageObjectWrite> objects,
   });
 
   /// List storage objects in a collection which have public read access.
@@ -466,8 +466,8 @@ abstract class NakamaBaseClient {
   /// - [collection] The collection to list over.
   /// - [limit] The number of objects to list. Maximum is 100.
   /// - [cursor] A cursor to paginate over the collection. Can be null.
-  Future<model.StorageObjectList> listStorageObjects({
-    required model.Session session,
+  Future<StorageObjectList> listStorageObjects({
+    required Session session,
     required String collection,
     int? limit,
     String? cursor,
@@ -479,17 +479,17 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [objectIds] The ids of the objects to delete.
   Future<void> deleteStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   });
 
   /// Read one or more objects from the storage engine.
   ///
   /// - [session] Current session.
   /// - [objectIds] The ids of the objects to read.
-  Future<List<model.StorageObject>> readStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+  Future<List<StorageObject>> readStorageObjects({
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   });
 
   /// List messages from a chat channel.
@@ -499,8 +499,8 @@ abstract class NakamaBaseClient {
   /// - [limit] The number of chat messages to list.
   /// - [forward] Fetch messages forward from the current cursor or the start.
   /// - [cursor] A cursor for the current position in the messages history to list.
-  Future<model.ChannelMessageList> listChannelMessages({
-    required model.Session session,
+  Future<ChannelMessageList> listChannelMessages({
+    required Session session,
     required String channelId,
     int limit = defaultLimit,
     bool? forward,
@@ -515,8 +515,8 @@ abstract class NakamaBaseClient {
   /// - [expiry] Expiry in seconds (since epoch) to begin fetching records from. 0 means from current time.
   /// - [limit] The number of records to list.
   /// - [cursor] A cursor for the current position in the leaderboard records to list.
-  Future<model.LeaderboardRecordList> listLeaderboardRecords({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecords({
+    required Session session,
     required String leaderboardName,
     List<String>? ownerIds,
     int limit = defaultLimit,
@@ -531,8 +531,8 @@ abstract class NakamaBaseClient {
   /// - [ownerId] The ID of the user to list around.
   /// - [expiry] Expiry in seconds (since epoch) to begin fetching records from. 0 means from current time.
   /// - [limit] The number of records to list.
-  Future<model.LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
+    required Session session,
     required String leaderboardName,
     required String ownerId,
     int limit = defaultLimit,
@@ -543,20 +543,20 @@ abstract class NakamaBaseClient {
   ///
   /// - [session] Current session.
   /// - [leaderboardName] The name of the leaderboard with the record to be deleted.
-  Future<model.LeaderboardRecord> writeLeaderboardRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeLeaderboardRecord({
+    required Session session,
     required String leaderboardName,
     required int score,
     int? subscore,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
   });
 
   /// Remove an owner's record from a leaderboard, if one exists.
   /// - [session] Current session.
   /// - [leaderboardName] The id of the leaderboard with the records to be deleted.
   Future<void> deleteLeaderboardRecord({
-    required model.Session session,
+    required Session session,
     required String leaderboardName,
   });
 
@@ -566,7 +566,7 @@ abstract class NakamaBaseClient {
   /// - [ids] The ids of the users to add or invite as friends.
   /// - [usernames] The usernames of the users to add as friends.
   Future<void> addFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   });
@@ -577,9 +577,9 @@ abstract class NakamaBaseClient {
   /// - [friendshipState] Filter by friendship state.
   /// - [limit] The number of friends to list.
   /// - [cursor] A cursor for the current position in the friends list.
-  Future<model.FriendsList> listFriends({
-    required model.Session session,
-    model.FriendshipState? friendshipState,
+  Future<FriendsList> listFriends({
+    required Session session,
+    FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   });
@@ -590,7 +590,7 @@ abstract class NakamaBaseClient {
   /// - [ids] The user ids to remove as friends.
   /// - [usernames] The usernames to remove as friends.
   Future<void> deleteFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   });
@@ -601,7 +601,7 @@ abstract class NakamaBaseClient {
   /// - [ids] The user ids to block.
   /// - [usernames] The usernames to block.
   Future<void> blockFriends({
-    required model.Session session,
+    required Session session,
     required List<String> ids,
     List<String>? usernames,
   });
@@ -615,8 +615,8 @@ abstract class NakamaBaseClient {
   /// - [langTag] A language tag in BCP-47 format for the group.
   /// - [open] If the group should have open membership. Defaults to false (private).
   /// - [maxCount] The maximum number of members allowed.
-  Future<model.Group> createGroup({
-    required model.Session session,
+  Future<Group> createGroup({
+    required Session session,
     required String name,
     String? avatarUrl,
     String? description,
@@ -636,7 +636,7 @@ abstract class NakamaBaseClient {
   /// - [langTag] A new language tag in BCP-47 format for the group.
   /// - [maxCount] The maximum number of members allowed.
   Future<void> updateGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required bool open,
     String? name,
@@ -655,8 +655,8 @@ abstract class NakamaBaseClient {
   /// - [members] The number of group members filter to apply to the group list.
   /// - [open] The open/closed filter to apply to the group list.
   /// - [limit] The number of groups to list.
-  Future<model.GroupList> listGroups({
-    required model.Session session,
+  Future<GroupList> listGroups({
+    required Session session,
     String? name,
     String? cursor,
     String? langTag,
@@ -670,7 +670,7 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [groupId] The group id to remove.
   Future<void> deleteGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   });
 
@@ -679,7 +679,7 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [groupId] The ID of the group to join.
   Future<void> joinGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   });
 
@@ -690,10 +690,10 @@ abstract class NakamaBaseClient {
   /// - [state] Filter by group membership state.
   /// - [limit] The number of records to list.
   /// - [cursor] A cursor for the current position in the listing.
-  Future<model.UserGroupList> listUserGroups({
-    required model.Session session,
+  Future<UserGroupList> listUserGroups({
+    required Session session,
     String? userId,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
     int limit = defaultLimit,
     String? cursor,
   });
@@ -705,12 +705,12 @@ abstract class NakamaBaseClient {
   /// - [state] Filter by group membership state.
   /// - [limit] The number of groups to list.
   /// - [cursor] A cursor for the current position in the group listing.
-  Future<model.GroupUserList> listGroupUsers({
-    required model.Session session,
+  Future<GroupUserList> listGroupUsers({
+    required Session session,
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
   });
 
   /// Add one or more users to the group.
@@ -719,7 +719,7 @@ abstract class NakamaBaseClient {
   /// - [groupId] The id of the group to add users into.
   /// - [userIds] The ids of the users to add or invite to the group.
   Future<void> addGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   });
@@ -730,7 +730,7 @@ abstract class NakamaBaseClient {
   /// - [groupId] The ID of the group to promote users into.
   /// - [userIds] The IDs of the users to promote.
   Future<void> promoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   });
@@ -741,7 +741,7 @@ abstract class NakamaBaseClient {
   /// - [groupId] The group to demote users in.
   /// - [userIds] The IDs of the users to demote.
   Future<void> demoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   });
@@ -752,7 +752,7 @@ abstract class NakamaBaseClient {
   /// - [groupId] The ID of the group.
   /// - [userIds] The IDs of the users to kick.
   Future<void> kickGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   });
@@ -763,7 +763,7 @@ abstract class NakamaBaseClient {
   /// - [groupId] The group to ban the users from.
   /// - [userIds] The IDs of the users to ban.
   Future<void> banGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   });
@@ -773,7 +773,7 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [groupId] The ID of the group to leave.
   Future<void> leaveGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   });
 
@@ -782,8 +782,8 @@ abstract class NakamaBaseClient {
   /// - [session] The session of the user.
   /// - [limit] The number of notifications to list.
   /// - [cursor] A cursor for the current position in notifications to list.
-  Future<model.NotificationList> listNotifications({
-    required model.Session session,
+  Future<NotificationList> listNotifications({
+    required Session session,
     int limit = defaultLimit,
     String? cursor,
   });
@@ -793,7 +793,7 @@ abstract class NakamaBaseClient {
   /// - [session] The session of the user.
   /// - [notificationIds] The notification ids to remove.
   Future<void> deleteNotifications({
-    required model.Session session,
+    required Session session,
     required Iterable<String> notificationIds,
   });
 
@@ -806,8 +806,8 @@ abstract class NakamaBaseClient {
   /// - [maxSize] The maximum number of match participants.
   /// - [minSize] The minimum number of match participants.
   /// - [query] A query for the matches to filter.
-  Future<List<model.Match>> listMatches({
-    required model.Session session,
+  Future<List<Match>> listMatches({
+    required Session session,
     bool? authoritative,
     String? label,
     int limit = defaultLimit,
@@ -821,7 +821,7 @@ abstract class NakamaBaseClient {
   /// - [session] Current session.
   /// - [tournamentId] The ID of the tournament to join.
   Future<void> joinTournament({
-    required model.Session session,
+    required Session session,
     required String tournamentId,
   });
 
@@ -834,8 +834,8 @@ abstract class NakamaBaseClient {
   /// - [endTime] The end time of the tournaments. If null, tournaments will not be filtered by end time.
   /// - [limit] The number of tournaments to list.
   /// - [cursor] An optional cursor for the next page of tournaments.
-  Future<model.TournamentList> listTournaments({
-    required model.Session session,
+  Future<TournamentList> listTournaments({
+    required Session session,
     int? categoryStart,
     int? categoryEnd,
     String? cursor,
@@ -852,8 +852,8 @@ abstract class NakamaBaseClient {
   /// - [expiry] Expiry in seconds (since epoch) to begin fetching records from.
   /// - [limit] The number of records to list.
   /// - [cursor] An optional cursor for the next page of tournament records.
-  Future<model.TournamentRecordList> listTournamentRecords({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecords({
+    required Session session,
     required String tournamentId,
     required Iterable<String> ownerIds,
     int? expiry,
@@ -868,8 +868,8 @@ abstract class NakamaBaseClient {
   /// - [ownerId] The ID of the owner to pivot around.
   /// - [expiry] Expiry in seconds (since epoch) to begin fetching records from.
   /// - [limit] The number of records to list.
-  Future<model.TournamentRecordList> listTournamentRecordsAroundOwner({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecordsAroundOwner({
+    required Session session,
     required String tournamentId,
     required String ownerId,
     int? expiry,
@@ -884,13 +884,13 @@ abstract class NakamaBaseClient {
   /// - [subscore] The sub score for the tournament record.
   /// - [metadata] The metadata for the tournament record.
   /// - [operator] The operator for the record that can be used to override the one set in the tournament.
-  Future<model.LeaderboardRecord> writeTournamentRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeTournamentRecord({
+    required Session session,
     required String tournamentId,
     required int score,
     int? subscore,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
   });
 
   /// Execute an RPC function on the server.
@@ -899,7 +899,7 @@ abstract class NakamaBaseClient {
   /// - [id] The ID of the function to execute.
   /// - [payload] The payload to send with the function call.
   Future<String?> rpc({
-    required model.Session session,
+    required Session session,
     required String id,
     String? payload,
   });

--- a/nakama/lib/src/nakama_client/nakama_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_client.dart
@@ -1,14 +1,15 @@
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/models/account.dart' as model;
-import 'package:nakama/src/models/channel_message.dart' as model;
-import 'package:nakama/src/models/friends.dart' as model;
-import 'package:nakama/src/models/group.dart' as model;
-import 'package:nakama/src/models/leaderboard.dart' as model;
-import 'package:nakama/src/models/match.dart' as model;
-import 'package:nakama/src/models/notification.dart' as model;
-import 'package:nakama/src/models/session.dart' as model;
-import 'package:nakama/src/models/storage.dart' as model;
-import 'package:nakama/src/models/tournament.dart' as model;
+import '../enum/friendship_state.dart' as model;
+import '../enum/group_membership_states.dart' as model;
+import '../models/account.dart' as model;
+import '../models/channel_message.dart' as model;
+import '../models/friends.dart' as model;
+import '../models/group.dart' as model;
+import '../models/leaderboard.dart' as model;
+import '../models/match.dart' as model;
+import '../models/notification.dart' as model;
+import '../models/session.dart' as model;
+import '../models/storage.dart' as model;
+import '../models/tournament.dart' as model;
 
 const _kDefaultAppKey = 'default';
 const defaultLimit = 20;
@@ -548,7 +549,7 @@ abstract class NakamaBaseClient {
     required int score,
     int? subscore,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
   });
 
   /// Remove an owner's record from a leaderboard, if one exists.
@@ -578,7 +579,7 @@ abstract class NakamaBaseClient {
   /// - [cursor] A cursor for the current position in the friends list.
   Future<model.FriendsList> listFriends({
     required model.Session session,
-    FriendshipState? friendshipState,
+    model.FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   });
@@ -692,7 +693,7 @@ abstract class NakamaBaseClient {
   Future<model.UserGroupList> listUserGroups({
     required model.Session session,
     String? userId,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
     int limit = defaultLimit,
     String? cursor,
   });
@@ -709,7 +710,7 @@ abstract class NakamaBaseClient {
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
   });
 
   /// Add one or more users to the group.
@@ -889,7 +890,7 @@ abstract class NakamaBaseClient {
     required int score,
     int? subscore,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
   });
 
   /// Execute an RPC function on the server.

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -1,22 +1,26 @@
 import 'dart:convert';
 
+import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 import 'package:logging/logging.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/api/proto/api/api.pb.dart';
-import 'package:nakama/src/api/proto/apigrpc/apigrpc.pbgrpc.dart';
-import 'package:nakama/src/models/account.dart' as model;
-import 'package:nakama/src/models/channel_message.dart' as model;
-import 'package:nakama/src/models/friends.dart' as model;
-import 'package:nakama/src/models/group.dart' as model;
-import 'package:nakama/src/models/leaderboard.dart' as model;
-import 'package:nakama/src/models/match.dart' as model;
-import 'package:nakama/src/models/notification.dart' as model;
-import 'package:nakama/src/models/session.dart' as model;
-import 'package:nakama/src/models/storage.dart' as model;
-import 'package:nakama/src/models/tournament.dart' as model;
+
+import '../api/api.dart' as api;
+import '../api/proto/api/api.pb.dart';
+import '../api/proto/apigrpc/apigrpc.pbgrpc.dart';
+import '../enum/friendship_state.dart' as model;
+import '../enum/group_membership_states.dart' as model;
+import '../models/account.dart' as model;
+import '../models/channel_message.dart' as model;
+import '../models/friends.dart' as model;
+import '../models/group.dart' as model;
+import '../models/leaderboard.dart' as model;
+import '../models/match.dart' as model;
+import '../models/notification.dart' as model;
+import '../models/session.dart' as model;
+import '../models/storage.dart' as model;
+import '../models/tournament.dart' as model;
+import 'nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
 
@@ -827,7 +831,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required int score,
     int? subscore,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
   }) async {
     final res = await _client.writeLeaderboardRecord(
       api.WriteLeaderboardRecordRequest(
@@ -876,7 +880,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   @override
   Future<model.FriendsList> listFriends({
     required model.Session session,
-    FriendshipState? friendshipState,
+    model.FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -1023,7 +1027,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required model.Session session,
     String? cursor,
     int limit = defaultLimit,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
     String? userId,
   }) async {
     final res = await _client.listUserGroups(
@@ -1045,7 +1049,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    GroupMembershipState? state,
+    model.GroupMembershipState? state,
   }) async {
     final res = await _client.listGroupUsers(
       api.ListGroupUsersRequest(
@@ -1298,7 +1302,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required model.Session session,
     required String tournamentId,
     String? metadata,
-    LeaderboardOperator? operator,
+    model.LeaderboardOperator? operator,
     int? score,
     int? subscore,
   }) async {
@@ -1338,7 +1342,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   @override
   Future<void> deleteStorageObjects({
     required model.Session session,
-    required Iterable<StorageObjectId> objectIds,
+    required Iterable<model.StorageObjectId> objectIds,
   }) async {
     await _client.deleteStorageObjects(
       api.DeleteStorageObjectsRequest(
@@ -1357,7 +1361,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   @override
   Future<List<model.StorageObject>> readStorageObjects({
     required model.Session session,
-    required Iterable<StorageObjectId> objectIds,
+    required Iterable<model.StorageObjectId> objectIds,
   }) async {
     final res = await _client.readStorageObjects(
       api.ReadStorageObjectsRequest(
@@ -1380,7 +1384,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   @override
   Future<void> writeStorageObjects({
     required model.Session session,
-    required Iterable<StorageObjectWrite> objects,
+    required Iterable<model.StorageObjectWrite> objects,
   }) async {
     await _client.writeStorageObjects(
       api.WriteStorageObjectsRequest(

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -1,24 +1,23 @@
 import 'dart:convert';
 
-import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 import 'package:logging/logging.dart';
 
 import '../api/api.dart' as api;
 import '../api/proto/apigrpc/apigrpc.pbgrpc.dart';
-import '../enum/friendship_state.dart' as model;
-import '../enum/group_membership_states.dart' as model;
-import '../models/account.dart' as model;
-import '../models/channel_message.dart' as model;
-import '../models/friends.dart' as model;
-import '../models/group.dart' as model;
-import '../models/leaderboard.dart' as model;
-import '../models/match.dart' as model;
-import '../models/notification.dart' as model;
-import '../models/session.dart' as model;
-import '../models/storage.dart' as model;
-import '../models/tournament.dart' as model;
+import '../enum/friendship_state.dart';
+import '../enum/group_membership_states.dart';
+import '../models/account.dart';
+import '../models/channel_message.dart';
+import '../models/friends.dart';
+import '../models/group.dart';
+import '../models/leaderboard.dart';
+import '../models/match.dart';
+import '../models/notification.dart';
+import '../models/session.dart';
+import '../models/storage.dart';
+import '../models/tournament.dart';
 import 'nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
@@ -103,24 +102,24 @@ class NakamaGrpcClient extends NakamaBaseClient {
   /// Use with cation, API can change every time.
   NakamaClient get rawGrpcClient => _client;
 
-  CallOptions _getSessionCallOptions(model.Session session) => CallOptions(
+  CallOptions _getSessionCallOptions(Session session) => CallOptions(
         metadata: {'authorization': 'Bearer ${session.token}'},
       );
 
   @override
-  Future<model.Session> sessionRefresh({
-    required model.Session session,
+  Future<Session> sessionRefresh({
+    required Session session,
     Map<String, String>? vars,
   }) async {
     final res = await _client.sessionRefresh(
       api.SessionRefreshRequest(token: session.refreshToken, vars: vars),
     );
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
-  Future<void> sessionLogout({required model.Session session}) async {
+  Future<void> sessionLogout({required Session session}) async {
     await _client.sessionLogout(api.SessionLogoutRequest(
       refreshToken: session.refreshToken,
       token: session.token,
@@ -128,7 +127,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateEmail({
+  Future<Session> authenticateEmail({
     String? email,
     String? username,
     required String password,
@@ -158,12 +157,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateEmail(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -181,7 +180,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkEmail({
-    required model.Session session,
+    required Session session,
     required String email,
     required String password,
     Map<String, String>? vars,
@@ -198,7 +197,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateDevice({
+  Future<Session> authenticateDevice({
     required String deviceId,
     bool create = true,
     String? username,
@@ -216,12 +215,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateDevice(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   }) async {
@@ -237,7 +236,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkDevice({
-    required model.Session session,
+    required Session session,
     required String deviceId,
     Map<String, String>? vars,
   }) async {
@@ -252,7 +251,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateFacebook({
+  Future<Session> authenticateFacebook({
     required String token,
     bool create = true,
     String? username,
@@ -272,12 +271,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateFacebook(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     bool import = false,
     Map<String, String>? vars,
@@ -296,7 +295,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkFacebook({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -311,7 +310,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateApple({
+  Future<Session> authenticateApple({
     required String token,
     bool create = true,
     String? username,
@@ -329,12 +328,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateApple(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -350,7 +349,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkApple({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -365,7 +364,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateFacebookInstantGame({
+  Future<Session> authenticateFacebookInstantGame({
     required String signedPlayerInfo,
     bool create = true,
     String? username,
@@ -383,12 +382,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateFacebookInstantGame(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   }) async {
@@ -404,7 +403,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkFacebookInstantGame({
-    required model.Session session,
+    required Session session,
     required String signedPlayerInfo,
     Map<String, String>? vars,
   }) async {
@@ -419,7 +418,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateGoogle({
+  Future<Session> authenticateGoogle({
     required String token,
     bool create = true,
     String? username,
@@ -437,12 +436,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateGoogle(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -458,7 +457,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkGoogle({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
   }) async {
@@ -473,7 +472,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateGameCenter({
+  Future<Session> authenticateGameCenter({
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -489,7 +488,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..account = (api.AccountGameCenter()
         ..playerId = playerId
         ..bundleId = bundleId
-        ..timestampSeconds = Int64(timestampSeconds)
+        ..timestampSeconds = api.Int64(timestampSeconds)
         ..salt = salt
         ..signature = signature
         ..publicKeyUrl = publicKeyUrl
@@ -501,12 +500,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateGameCenter(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -518,7 +517,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     final request = api.AccountGameCenter()
       ..playerId = playerId
       ..bundleId = bundleId
-      ..timestampSeconds = Int64(timestampSeconds)
+      ..timestampSeconds = api.Int64(timestampSeconds)
       ..salt = salt
       ..signature = signature
       ..publicKeyUrl = publicKeyUrl
@@ -532,7 +531,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkGameCenter({
-    required model.Session session,
+    required Session session,
     required String playerId,
     required String bundleId,
     required int timestampSeconds,
@@ -544,7 +543,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     final request = api.AccountGameCenter()
       ..playerId = playerId
       ..bundleId = bundleId
-      ..timestampSeconds = Int64(timestampSeconds)
+      ..timestampSeconds = api.Int64(timestampSeconds)
       ..salt = salt
       ..signature = signature
       ..publicKeyUrl = publicKeyUrl
@@ -557,7 +556,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateSteam({
+  Future<Session> authenticateSteam({
     required String token,
     bool create = true,
     String? username,
@@ -577,12 +576,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateSteam(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -601,7 +600,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkSteam({
-    required model.Session session,
+    required Session session,
     required String token,
     Map<String, String>? vars,
     bool import = false,
@@ -619,7 +618,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Session> authenticateCustom({
+  Future<Session> authenticateCustom({
     required String id,
     bool create = true,
     String? username,
@@ -637,12 +636,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
     final res = await _client.authenticateCustom(request);
 
-    return model.Session.fromDto(res);
+    return Session.fromDto(res);
   }
 
   @override
   Future<void> linkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   }) async {
@@ -658,7 +657,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> unlinkCustom({
-    required model.Session session,
+    required Session session,
     required String id,
     Map<String, String>? vars,
   }) async {
@@ -673,18 +672,18 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Account> getAccount(model.Session session) async {
+  Future<Account> getAccount(Session session) async {
     final res = await _client.getAccount(
       api.Empty(),
       options: _getSessionCallOptions(session),
     );
 
-    return model.Account.fromDto(res);
+    return Account.fromDto(res);
   }
 
   @override
   Future<void> updateAccount({
-    required model.Session session,
+    required Session session,
     String? username,
     String? displayName,
     String? avatarUrl,
@@ -707,8 +706,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<List<model.User>> getUsers({
-    required model.Session session,
+  Future<List<User>> getUsers({
+    required Session session,
     List<String>? facebookIds,
     List<String>? ids,
     List<String>? usernames,
@@ -722,12 +721,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return res.users.map((e) => model.User.fromDto(e)).toList(growable: false);
+    return res.users.map((e) => User.fromDto(e)).toList(growable: false);
   }
 
   @override
-  Future<model.StorageObjectList> listStorageObjects({
-    required model.Session session,
+  Future<StorageObjectList> listStorageObjects({
+    required Session session,
     String? collection,
     String? cursor,
     String? userId,
@@ -743,12 +742,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.StorageObjectList.fromDto(res);
+    return StorageObjectList.fromDto(res);
   }
 
   @override
-  Future<model.ChannelMessageList> listChannelMessages({
-    required model.Session session,
+  Future<ChannelMessageList> listChannelMessages({
+    required Session session,
     required String channelId,
     int limit = 20,
     bool? forward,
@@ -766,12 +765,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.ChannelMessageList.fromDto(res);
+    return ChannelMessageList.fromDto(res);
   }
 
   @override
-  Future<model.LeaderboardRecordList> listLeaderboardRecords({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecords({
+    required Session session,
     required String leaderboardName,
     List<String>? ownerIds,
     int limit = 20,
@@ -789,17 +788,17 @@ class NakamaGrpcClient extends NakamaBaseClient {
         expiry: expiry == null
             ? null
             : api.Int64Value(
-                value: Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
+                value: api.Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
       ),
       options: _getSessionCallOptions(session),
     );
 
-    return model.LeaderboardRecordList.fromDto(res);
+    return LeaderboardRecordList.fromDto(res);
   }
 
   @override
-  Future<model.LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
-    required model.Session session,
+  Future<LeaderboardRecordList> listLeaderboardRecordsAroundOwner({
+    required Session session,
     required String leaderboardName,
     required String ownerId,
     int limit = 20,
@@ -815,29 +814,29 @@ class NakamaGrpcClient extends NakamaBaseClient {
         expiry: expiry == null
             ? null
             : api.Int64Value(
-                value: Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
+                value: api.Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
       ),
       options: _getSessionCallOptions(session),
     );
 
-    return model.LeaderboardRecordList.fromDto(res);
+    return LeaderboardRecordList.fromDto(res);
   }
 
   @override
-  Future<model.LeaderboardRecord> writeLeaderboardRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeLeaderboardRecord({
+    required Session session,
     required String leaderboardName,
     required int score,
     int? subscore,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
   }) async {
     final res = await _client.writeLeaderboardRecord(
       api.WriteLeaderboardRecordRequest(
         leaderboardId: leaderboardName,
         record: api.WriteLeaderboardRecordRequest_LeaderboardRecordWrite(
-          score: Int64(score),
-          subscore: subscore == null ? null : Int64(subscore),
+          score: api.Int64(score),
+          subscore: subscore == null ? null : api.Int64(subscore),
           metadata: metadata,
           operator: api.Operator.valueOf(operator?.index ?? 0),
         ),
@@ -845,12 +844,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.LeaderboardRecord.fromDto(res);
+    return LeaderboardRecord.fromDto(res);
   }
 
   @override
   Future<void> deleteLeaderboardRecord({
-    required model.Session session,
+    required Session session,
     required String leaderboardName,
   }) async {
     await _client.deleteLeaderboardRecord(
@@ -863,7 +862,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> addFriends({
-    required model.Session session,
+    required Session session,
     List<String>? usernames,
     List<String>? ids,
   }) async {
@@ -877,9 +876,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.FriendsList> listFriends({
-    required model.Session session,
-    model.FriendshipState? friendshipState,
+  Future<FriendsList> listFriends({
+    required Session session,
+    FriendshipState? friendshipState,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -892,12 +891,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.FriendsList.fromDto(res);
+    return FriendsList.fromDto(res);
   }
 
   @override
   Future<void> deleteFriends({
-    required model.Session session,
+    required Session session,
     List<String>? usernames,
     List<String>? ids,
   }) async {
@@ -912,7 +911,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> blockFriends({
-    required model.Session session,
+    required Session session,
     List<String>? usernames,
     List<String>? ids,
   }) async {
@@ -926,8 +925,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.Group> createGroup({
-    required model.Session session,
+  Future<Group> createGroup({
+    required Session session,
     required String name,
     String? avatarUrl,
     String? description,
@@ -947,12 +946,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.Group.fromDto(res);
+    return Group.fromDto(res);
   }
 
   @override
   Future<void> updateGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
     String? name,
     String? avatarUrl,
@@ -975,8 +974,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.GroupList> listGroups({
-    required model.Session session,
+  Future<GroupList> listGroups({
+    required Session session,
     String? name,
     String? cursor,
     String? langTag,
@@ -996,12 +995,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.GroupList.fromDto(res);
+    return GroupList.fromDto(res);
   }
 
   @override
   Future<void> deleteGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     await _client.deleteGroup(
@@ -1012,7 +1011,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> joinGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     await _client.joinGroup(
@@ -1022,11 +1021,11 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.UserGroupList> listUserGroups({
-    required model.Session session,
+  Future<UserGroupList> listUserGroups({
+    required Session session,
     String? cursor,
     int limit = defaultLimit,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
     String? userId,
   }) async {
     final res = await _client.listUserGroups(
@@ -1039,16 +1038,16 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.UserGroupList.fromDto(res);
+    return UserGroupList.fromDto(res);
   }
 
   @override
-  Future<model.GroupUserList> listGroupUsers({
-    required model.Session session,
+  Future<GroupUserList> listGroupUsers({
+    required Session session,
     required String groupId,
     String? cursor,
     int limit = defaultLimit,
-    model.GroupMembershipState? state,
+    GroupMembershipState? state,
   }) async {
     final res = await _client.listGroupUsers(
       api.ListGroupUsersRequest(
@@ -1060,12 +1059,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.GroupUserList.fromDto(res);
+    return GroupUserList.fromDto(res);
   }
 
   @override
   Future<void> addGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1080,7 +1079,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> promoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1095,7 +1094,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> demoteGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1110,7 +1109,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> kickGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1125,7 +1124,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> banGroupUsers({
-    required model.Session session,
+    required Session session,
     required String groupId,
     required Iterable<String> userIds,
   }) async {
@@ -1140,7 +1139,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> leaveGroup({
-    required model.Session session,
+    required Session session,
     required String groupId,
   }) async {
     await _client.leaveGroup(
@@ -1152,8 +1151,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.NotificationList> listNotifications({
-    required model.Session session,
+  Future<NotificationList> listNotifications({
+    required Session session,
     int limit = defaultLimit,
     String? cursor,
   }) async {
@@ -1165,12 +1164,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.NotificationList.fromDto(res);
+    return NotificationList.fromDto(res);
   }
 
   @override
   Future<void> deleteNotifications({
-    required model.Session session,
+    required Session session,
     required Iterable<String> notificationIds,
   }) async {
     await _client.deleteNotifications(
@@ -1182,8 +1181,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<List<model.Match>> listMatches({
-    required model.Session session,
+  Future<List<Match>> listMatches({
+    required Session session,
     bool? authoritative,
     String? label,
     int limit = defaultLimit,
@@ -1203,14 +1202,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return res.matches
-        .map((e) => model.Match.fromDto(e))
-        .toList(growable: false);
+    return res.matches.map((e) => Match.fromDto(e)).toList(growable: false);
   }
 
   @override
   Future<void> joinTournament({
-    required model.Session session,
+    required Session session,
     required String tournamentId,
   }) async {
     await _client.joinTournament(
@@ -1222,8 +1219,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<model.TournamentList> listTournaments({
-    required model.Session session,
+  Future<TournamentList> listTournaments({
+    required Session session,
     int? categoryStart,
     int? categoryEnd,
     String? cursor,
@@ -1249,12 +1246,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.TournamentList.fromDto(res);
+    return TournamentList.fromDto(res);
   }
 
   @override
-  Future<model.TournamentRecordList> listTournamentRecords({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecords({
+    required Session session,
     required String tournamentId,
     Iterable<String>? ownerIds,
     int? expiry,
@@ -1264,7 +1261,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
     final res = await _client.listTournamentRecords(
       api.ListTournamentRecordsRequest(
         cursor: cursor,
-        expiry: expiry == null ? null : api.Int64Value(value: Int64(expiry)),
+        expiry:
+            expiry == null ? null : api.Int64Value(value: api.Int64(expiry)),
         limit: api.Int32Value(value: limit),
         ownerIds: ownerIds,
         tournamentId: tournamentId,
@@ -1272,12 +1270,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.TournamentRecordList.fromDto(res);
+    return TournamentRecordList.fromDto(res);
   }
 
   @override
-  Future<model.TournamentRecordList> listTournamentRecordsAroundOwner({
-    required model.Session session,
+  Future<TournamentRecordList> listTournamentRecordsAroundOwner({
+    required Session session,
     required String tournamentId,
     required String ownerId,
     int? expiry,
@@ -1285,7 +1283,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     final res = await _client.listTournamentRecordsAroundOwner(
       api.ListTournamentRecordsAroundOwnerRequest(
-        expiry: expiry == null ? null : api.Int64Value(value: Int64(expiry)),
+        expiry:
+            expiry == null ? null : api.Int64Value(value: api.Int64(expiry)),
         limit: api.UInt32Value(value: limit),
         ownerId: ownerId,
         tournamentId: tournamentId,
@@ -1293,15 +1292,15 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return model.TournamentRecordList.fromDto(res);
+    return TournamentRecordList.fromDto(res);
   }
 
   @override
-  Future<model.LeaderboardRecord> writeTournamentRecord({
-    required model.Session session,
+  Future<LeaderboardRecord> writeTournamentRecord({
+    required Session session,
     required String tournamentId,
     String? metadata,
-    model.LeaderboardOperator? operator,
+    LeaderboardOperator? operator,
     int? score,
     int? subscore,
   }) async {
@@ -1311,19 +1310,19 @@ class NakamaGrpcClient extends NakamaBaseClient {
         record: api.WriteTournamentRecordRequest_TournamentRecordWrite(
           metadata: metadata,
           operator: api.Operator.valueOf(operator?.index ?? 0),
-          score: score != null ? Int64(score) : null,
-          subscore: subscore != null ? Int64(subscore) : null,
+          score: score != null ? api.Int64(score) : null,
+          subscore: subscore != null ? api.Int64(subscore) : null,
         ),
       ),
       options: _getSessionCallOptions(session),
     );
 
-    return model.LeaderboardRecord.fromDto(res);
+    return LeaderboardRecord.fromDto(res);
   }
 
   @override
   Future<String?> rpc({
-    required model.Session session,
+    required Session session,
     required String id,
     String? payload,
   }) async {
@@ -1340,8 +1339,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> deleteStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   }) async {
     await _client.deleteStorageObjects(
       api.DeleteStorageObjectsRequest(
@@ -1358,9 +1357,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<List<model.StorageObject>> readStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectId> objectIds,
+  Future<List<StorageObject>> readStorageObjects({
+    required Session session,
+    required Iterable<StorageObjectId> objectIds,
   }) async {
     final res = await _client.readStorageObjects(
       api.ReadStorageObjectsRequest(
@@ -1376,14 +1375,14 @@ class NakamaGrpcClient extends NakamaBaseClient {
     );
 
     return res.objects
-        .map((e) => model.StorageObject.fromDto(e))
+        .map((e) => StorageObject.fromDto(e))
         .toList(growable: false);
   }
 
   @override
   Future<void> writeStorageObjects({
-    required model.Session session,
-    required Iterable<model.StorageObjectWrite> objects,
+    required Session session,
+    required Iterable<StorageObjectWrite> objects,
   }) async {
     await _client.writeStorageObjects(
       api.WriteStorageObjectsRequest(
@@ -1395,7 +1394,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> importFacebookFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,
@@ -1411,7 +1410,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<void> importSteamFriends({
-    required model.Session session,
+    required Session session,
     required String token,
     bool reset = false,
     Map<String, String>? vars,

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -6,7 +6,6 @@ import 'package:grpc/grpc_connection_interface.dart';
 import 'package:logging/logging.dart';
 
 import '../api/api.dart' as api;
-import '../api/proto/api/api.pb.dart';
 import '../api/proto/apigrpc/apigrpc.pbgrpc.dart';
 import '../enum/friendship_state.dart' as model;
 import '../enum/group_membership_states.dart' as model;
@@ -840,7 +839,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
           score: Int64(score),
           subscore: subscore == null ? null : Int64(subscore),
           metadata: metadata,
-          operator: Operator.valueOf(operator?.index ?? 0),
+          operator: api.Operator.valueOf(operator?.index ?? 0),
         ),
       ),
       options: _getSessionCallOptions(session),
@@ -1311,7 +1310,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
         tournamentId: tournamentId,
         record: api.WriteTournamentRecordRequest_TournamentRecordWrite(
           metadata: metadata,
-          operator: Operator.valueOf(operator?.index ?? 0),
+          operator: api.Operator.valueOf(operator?.index ?? 0),
           score: score != null ? Int64(score) : null,
           subscore: subscore != null ? Int64(subscore) : null,
         ),
@@ -1403,7 +1402,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     await _client.importFacebookFriends(
       api.ImportFacebookFriendsRequest(
-        account: AccountFacebook(token: token, vars: vars),
+        account: api.AccountFacebook(token: token, vars: vars),
         reset: api.BoolValue(value: reset),
       ),
       options: _getSessionCallOptions(session),
@@ -1419,7 +1418,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     await _client.importSteamFriends(
       api.ImportSteamFriendsRequest(
-        account: AccountSteam(token: token, vars: vars),
+        account: api.AccountSteam(token: token, vars: vars),
         reset: api.BoolValue(value: reset),
       ),
       options: _getSessionCallOptions(session),

--- a/nakama/lib/src/nakama_client/stub/api_client.dart
+++ b/nakama/lib/src/nakama_client/stub/api_client.dart
@@ -1,5 +1,5 @@
-import 'package:nakama/src/nakama_client/nakama_api_client.dart';
-import 'package:nakama/src/nakama_client/nakama_client.dart';
+import '../nakama_api_client.dart';
+import '../nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
 

--- a/nakama/lib/src/nakama_client/stub/grpc_client.dart
+++ b/nakama/lib/src/nakama_client/stub/grpc_client.dart
@@ -1,5 +1,5 @@
-import 'package:nakama/src/nakama_client/nakama_client.dart';
-import 'package:nakama/src/nakama_client/nakama_grpc_client.dart';
+import '../nakama_client.dart';
+import '../nakama_grpc_client.dart';
 
 const _kDefaultAppKey = 'default';
 

--- a/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
+++ b/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
@@ -1,4 +1,4 @@
-import 'package:nakama/src/nakama_client/nakama_client.dart';
+import '../nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
 

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -305,7 +305,7 @@ class NakamaWebsocketClient {
       rtapi.Envelope(matchCreate: rtapi.MatchCreate(name: name)),
     );
 
-    return Match.fromRtpb(res);
+    return Match.fromRtDto(res);
   }
 
   /// # Creating parties
@@ -422,7 +422,7 @@ class NakamaWebsocketClient {
       ),
     );
 
-    return Match.fromRtpb(res);
+    return Match.fromRtDto(res);
   }
 
   Future<void> leaveMatch(String matchId) async {

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -2,10 +2,18 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:logging/logging.dart';
-import 'package:nakama/nakama.dart';
-import 'package:nakama/src/api/api.dart' as api;
-import 'package:nakama/src/api/rtapi.dart' as rtpb;
 import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'api/api.dart' as api;
+import 'api/rtapi.dart' as rtapi;
+import 'enum/channel_type.dart';
+import 'models/chat.dart';
+import 'models/match.dart';
+import 'models/matchmaker.dart';
+import 'models/notification.dart';
+import 'models/party.dart';
+import 'models/rpc.dart';
+import 'models/status.dart';
 
 class NakamaWebsocketClient {
   static final _log = Logger('NakamaWebsocketClient');
@@ -189,7 +197,7 @@ class NakamaWebsocketClient {
 
   void _onData(msg) {
     try {
-      final receivedEnvelope = rtpb.Envelope.fromBuffer(msg);
+      final receivedEnvelope = rtapi.Envelope.fromBuffer(msg);
       _log.info('onData: $receivedEnvelope');
 
       if (receivedEnvelope.cid.isNotEmpty) {
@@ -197,19 +205,19 @@ class NakamaWebsocketClient {
         final waitingFuture = _futures[int.parse(receivedEnvelope.cid)];
 
         // ? Is there any chance to do this better with <T>?
-        if (waitingFuture is Completer<rtpb.Match>) {
+        if (waitingFuture is Completer<rtapi.Match>) {
           return waitingFuture.complete(receivedEnvelope.match);
-        } else if (waitingFuture is Completer<rtpb.MatchmakerTicket>) {
+        } else if (waitingFuture is Completer<rtapi.MatchmakerTicket>) {
           return waitingFuture.complete(receivedEnvelope.matchmakerTicket);
-        } else if (waitingFuture is Completer<rtpb.Status>) {
+        } else if (waitingFuture is Completer<rtapi.Status>) {
           return waitingFuture.complete(receivedEnvelope.status);
-        } else if (waitingFuture is Completer<rtpb.Channel>) {
+        } else if (waitingFuture is Completer<rtapi.Channel>) {
           return waitingFuture.complete(receivedEnvelope.channel);
-        } else if (waitingFuture is Completer<rtpb.ChannelMessageAck>) {
+        } else if (waitingFuture is Completer<rtapi.ChannelMessageAck>) {
           return waitingFuture.complete(receivedEnvelope.channelMessageAck);
-        } else if (waitingFuture is Completer<rtpb.Party>) {
+        } else if (waitingFuture is Completer<rtapi.Party>) {
           return waitingFuture.complete(receivedEnvelope.party);
-        } else if (waitingFuture is Completer<rtpb.PartyMatchmakerTicket>) {
+        } else if (waitingFuture is Completer<rtapi.PartyMatchmakerTicket>) {
           return waitingFuture.complete(receivedEnvelope.partyMatchmakerTicket);
         } else {
           return waitingFuture.complete();
@@ -217,50 +225,50 @@ class NakamaWebsocketClient {
       } else {
         // map server messages
         switch (receivedEnvelope.whichMessage()) {
-          case rtpb.Envelope_Message.channelPresenceEvent:
+          case rtapi.Envelope_Message.channelPresenceEvent:
             return _onChannelPresenceController.add(
               ChannelPresenceEvent.fromDto(
                 receivedEnvelope.channelPresenceEvent,
               ),
             );
-          case rtpb.Envelope_Message.matchmakerMatched:
+          case rtapi.Envelope_Message.matchmakerMatched:
             return _onMatchmakerMatchedController.add(
               MatchmakerMatched.fromDto(receivedEnvelope.matchmakerMatched),
             );
-          case rtpb.Envelope_Message.matchData:
+          case rtapi.Envelope_Message.matchData:
             return _onMatchDataController
                 .add(MatchData.fromDto(receivedEnvelope.matchData));
-          case rtpb.Envelope_Message.partyData:
+          case rtapi.Envelope_Message.partyData:
             return _onPartyDataController
                 .add(PartyData.fromDto(receivedEnvelope.partyData));
-          case rtpb.Envelope_Message.partyPresenceEvent:
+          case rtapi.Envelope_Message.partyPresenceEvent:
             return _onPartyPresenceController.add(
               PartyPresenceEvent.fromDto(receivedEnvelope.partyPresenceEvent),
             );
-          case rtpb.Envelope_Message.partyLeader:
+          case rtapi.Envelope_Message.partyLeader:
             return _onPartyLeaderController
                 .add(PartyLeader.fromDto(receivedEnvelope.partyLeader));
-          case rtpb.Envelope_Message.matchPresenceEvent:
+          case rtapi.Envelope_Message.matchPresenceEvent:
             return _onMatchPresenceController.add(
               MatchPresenceEvent.fromDto(receivedEnvelope.matchPresenceEvent),
             );
-          case rtpb.Envelope_Message.notifications:
+          case rtapi.Envelope_Message.notifications:
             receivedEnvelope.notifications.notifications
                 .map((e) => Notification.fromDto(e))
                 .forEach((element) => _onNotificationsController.add(element));
             return;
-          case rtpb.Envelope_Message.statusPresenceEvent:
+          case rtapi.Envelope_Message.statusPresenceEvent:
             return _onStatusPresenceController.add(
               StatusPresenceEvent.fromDto(receivedEnvelope.statusPresenceEvent),
             );
-          case rtpb.Envelope_Message.streamPresenceEvent:
+          case rtapi.Envelope_Message.streamPresenceEvent:
             return _onStreamPresenceController.add(
               StreamPresenceEvent.fromDto(receivedEnvelope.streamPresenceEvent),
             );
-          case rtpb.Envelope_Message.streamData:
+          case rtapi.Envelope_Message.streamData:
             return _onStreamDataController
                 .add(RealtimeStreamData.fromDto(receivedEnvelope.streamData));
-          case rtpb.Envelope_Message.channelMessage:
+          case rtapi.Envelope_Message.channelMessage:
             return _onChannelMessageController
                 .add(receivedEnvelope.channelMessage);
           default:
@@ -273,7 +281,7 @@ class NakamaWebsocketClient {
     }
   }
 
-  Future<T> _send<T>(rtpb.Envelope envelope) {
+  Future<T> _send<T>(rtapi.Envelope envelope) {
     final ticket = _createTicket<T>();
     _channel.sink.add((envelope..cid = ticket.toString()).writeToBuffer());
     return _futures[ticket].future as Future<T>;
@@ -286,15 +294,15 @@ class NakamaWebsocketClient {
   }
 
   Future updateStatus(String status) => _send<void>(
-        rtpb.Envelope(
+        rtapi.Envelope(
           statusUpdate:
-              rtpb.StatusUpdate(status: api.StringValue(value: status)),
+              rtapi.StatusUpdate(status: api.StringValue(value: status)),
         ),
       );
 
   Future<Match> createMatch([String? name]) async {
-    final res = await _send<rtpb.Match>(
-      rtpb.Envelope(matchCreate: rtpb.MatchCreate(name: name)),
+    final res = await _send<rtapi.Match>(
+      rtapi.Envelope(matchCreate: rtapi.MatchCreate(name: name)),
     );
 
     return Match.fromRtpb(res);
@@ -305,8 +313,8 @@ class NakamaWebsocketClient {
   /// maximum number of players and can be open to automatically accept players
   /// or closed so that the party leader can accept incoming join requests.
   Future<Party> createParty({int? maxSize, bool? open}) async {
-    final res = await _send<rtpb.Party>(rtpb.Envelope(
-        partyCreate: rtpb.PartyCreate(
+    final res = await _send<rtapi.Party>(rtapi.Envelope(
+        partyCreate: rtapi.PartyCreate(
       maxSize: maxSize,
       open: open,
     )));
@@ -315,9 +323,9 @@ class NakamaWebsocketClient {
   }
 
   Future<Party> joinParty(String partyId) async {
-    final res = await _send<rtpb.Party>(
-      rtpb.Envelope(
-        partyJoin: rtpb.PartyJoin(partyId: partyId),
+    final res = await _send<rtapi.Party>(
+      rtapi.Envelope(
+        partyJoin: rtapi.PartyJoin(partyId: partyId),
       ),
     );
 
@@ -328,10 +336,10 @@ class NakamaWebsocketClient {
     required String partyId,
     required UserPresence newLeader,
   }) async {
-    await _send(rtpb.Envelope(
-        partyPromote: rtpb.PartyPromote(
+    await _send(rtapi.Envelope(
+        partyPromote: rtapi.PartyPromote(
       partyId: partyId,
-      presence: rtpb.UserPresence(
+      presence: rtapi.UserPresence(
         userId: newLeader.userId,
         sessionId: newLeader.sessionId,
         username: newLeader.username,
@@ -342,16 +350,16 @@ class NakamaWebsocketClient {
   }
 
   Future<void> leaveParty(String partyId) async {
-    await _send<rtpb.Party>(rtpb.Envelope(
-      partyLeave: rtpb.PartyLeave(partyId: partyId),
+    await _send<rtapi.Party>(rtapi.Envelope(
+      partyLeave: rtapi.PartyLeave(partyId: partyId),
     ));
   }
 
   Future<void> acceptPartyMember(String partyId, UserPresence presence) async {
-    await _send<rtpb.Party>(rtpb.Envelope(
-      partyAccept: rtpb.PartyAccept(
+    await _send<rtapi.Party>(rtapi.Envelope(
+      partyAccept: rtapi.PartyAccept(
         partyId: partyId,
-        presence: rtpb.UserPresence(
+        presence: rtapi.UserPresence(
           userId: presence.userId,
           sessionId: presence.sessionId,
           username: presence.username,
@@ -363,10 +371,10 @@ class NakamaWebsocketClient {
   }
 
   Future<void> removePartyMember(String partyId, UserPresence presence) async {
-    await _send<void>(rtpb.Envelope(
-      partyRemove: rtpb.PartyRemove(
+    await _send<void>(rtapi.Envelope(
+      partyRemove: rtapi.PartyRemove(
         partyId: partyId,
-        presence: rtpb.UserPresence(
+        presence: rtapi.UserPresence(
           userId: presence.userId,
           sessionId: presence.sessionId,
           username: presence.username,
@@ -385,8 +393,8 @@ class NakamaWebsocketClient {
     Map<String, double>? numericProperties,
     Map<String, String>? stringProperties,
   }) async {
-    final res = await _send<rtpb.PartyMatchmakerTicket>(rtpb.Envelope(
-        partyMatchmakerAdd: rtpb.PartyMatchmakerAdd(
+    final res = await _send<rtapi.PartyMatchmakerTicket>(rtapi.Envelope(
+        partyMatchmakerAdd: rtapi.PartyMatchmakerAdd(
       partyId: partyId,
       minCount: minCount,
       maxCount: maxCount,
@@ -399,8 +407,8 @@ class NakamaWebsocketClient {
   }
 
   Future<void> closeParty(String partyId) async {
-    await _send<void>(rtpb.Envelope(
-      partyClose: rtpb.PartyClose(partyId: partyId),
+    await _send<void>(rtapi.Envelope(
+      partyClose: rtapi.PartyClose(partyId: partyId),
     ));
   }
 
@@ -408,9 +416,9 @@ class NakamaWebsocketClient {
     String matchId, {
     String? token,
   }) async {
-    final res = await _send<rtpb.Match>(
-      rtpb.Envelope(
-        matchJoin: rtpb.MatchJoin(matchId: matchId, token: token),
+    final res = await _send<rtapi.Match>(
+      rtapi.Envelope(
+        matchJoin: rtapi.MatchJoin(matchId: matchId, token: token),
       ),
     );
 
@@ -419,7 +427,7 @@ class NakamaWebsocketClient {
 
   Future<void> leaveMatch(String matchId) async {
     await _send<void>(
-      rtpb.Envelope(matchLeave: rtpb.MatchLeave(matchId: matchId)),
+      rtapi.Envelope(matchLeave: rtapi.MatchLeave(matchId: matchId)),
     );
   }
 
@@ -433,8 +441,8 @@ class NakamaWebsocketClient {
     assert(minCount >= 2);
     assert(maxCount == null || maxCount >= minCount);
 
-    final ticket = await _send<rtpb.MatchmakerTicket>(rtpb.Envelope(
-        matchmakerAdd: rtpb.MatchmakerAdd(
+    final ticket = await _send<rtapi.MatchmakerTicket>(rtapi.Envelope(
+        matchmakerAdd: rtapi.MatchmakerAdd(
       maxCount: maxCount,
       minCount: minCount,
       numericProperties: numericProperties,
@@ -447,13 +455,13 @@ class NakamaWebsocketClient {
 
   Future<void> removeMatchmaker(String ticket) async {
     await _send(
-      rtpb.Envelope(matchmakerRemove: rtpb.MatchmakerRemove(ticket: ticket)),
+      rtapi.Envelope(matchmakerRemove: rtapi.MatchmakerRemove(ticket: ticket)),
     );
   }
 
   Future<Rpc> rpc({required String id, String? payload}) async {
     final res = await _send<api.Rpc>(
-      rtpb.Envelope(rpc: api.Rpc(id: id, payload: payload)),
+      rtapi.Envelope(rpc: api.Rpc(id: id, payload: payload)),
     );
 
     return Rpc.fromDto(res);
@@ -463,8 +471,8 @@ class NakamaWebsocketClient {
     List<String>? userIds,
     List<String>? usernames,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
-        statusFollow: rtpb.StatusFollow(
+    final res = await _send<rtapi.Status>(rtapi.Envelope(
+        statusFollow: rtapi.StatusFollow(
       userIds: userIds,
       usernames: usernames,
     )));
@@ -476,8 +484,8 @@ class NakamaWebsocketClient {
     List<String> list, {
     List<String>? userIds,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
-        statusUnfollow: rtpb.StatusUnfollow(
+    final res = await _send<rtapi.Status>(rtapi.Envelope(
+        statusUnfollow: rtapi.StatusUnfollow(
       userIds: userIds,
     )));
 
@@ -490,13 +498,13 @@ class NakamaWebsocketClient {
     required List<int> data,
     Iterable<UserPresence>? presences,
   }) async {
-    _send<void>(rtpb.Envelope(
-        matchDataSend: rtpb.MatchDataSend(
+    _send<void>(rtapi.Envelope(
+        matchDataSend: rtapi.MatchDataSend(
       matchId: matchId,
       opCode: api.Int64(opCode),
       data: data,
       presences: presences?.map((e) {
-        return rtpb.UserPresence(
+        return rtapi.UserPresence(
           userId: e.userId,
           sessionId: e.sessionId,
           username: e.username,
@@ -512,8 +520,8 @@ class NakamaWebsocketClient {
     required int opCode,
     required List<int> data,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
-        partyDataSend: rtpb.PartyDataSend(
+    final res = await _send<rtapi.Status>(rtapi.Envelope(
+        partyDataSend: rtapi.PartyDataSend(
       partyId: partyId,
       opCode: api.Int64(opCode),
       data: data,
@@ -528,19 +536,19 @@ class NakamaWebsocketClient {
     required bool persistence,
     required bool hidden,
   }) async {
-    final res = await _send<rtpb.Channel>(rtpb.Envelope(
-        channelJoin: rtpb.ChannelJoin(
+    final res = await _send<rtapi.Channel>(rtapi.Envelope(
+        channelJoin: rtapi.ChannelJoin(
       target: target,
       type: () {
         switch (type) {
           case ChannelType.room:
-            return rtpb.ChannelJoin_Type.ROOM;
+            return rtapi.ChannelJoin_Type.ROOM;
           case ChannelType.group:
-            return rtpb.ChannelJoin_Type.GROUP;
+            return rtapi.ChannelJoin_Type.GROUP;
           case ChannelType.directMessage:
-            return rtpb.ChannelJoin_Type.DIRECT_MESSAGE;
+            return rtapi.ChannelJoin_Type.DIRECT_MESSAGE;
           default:
-            return rtpb.ChannelJoin_Type.TYPE_UNSPECIFIED;
+            return rtapi.ChannelJoin_Type.TYPE_UNSPECIFIED;
         }
       }()
           .value,
@@ -555,7 +563,7 @@ class NakamaWebsocketClient {
     required String channelId,
   }) async {
     await _send(
-      rtpb.Envelope(channelLeave: rtpb.ChannelLeave(channelId: channelId)),
+      rtapi.Envelope(channelLeave: rtapi.ChannelLeave(channelId: channelId)),
     );
   }
 
@@ -563,8 +571,8 @@ class NakamaWebsocketClient {
     required String channelId,
     required Map<String, String> content,
   }) async {
-    final res = await _send<rtpb.ChannelMessageAck>(rtpb.Envelope(
-        channelMessageSend: rtpb.ChannelMessageSend(
+    final res = await _send<rtapi.ChannelMessageAck>(rtapi.Envelope(
+        channelMessageSend: rtapi.ChannelMessageSend(
       channelId: channelId,
       content: jsonEncode(content),
     )));
@@ -577,8 +585,8 @@ class NakamaWebsocketClient {
     required String messageId,
     required Map<String, String> content,
   }) async {
-    final res = await _send<rtpb.ChannelMessageAck>(rtpb.Envelope(
-        channelMessageUpdate: rtpb.ChannelMessageUpdate(
+    final res = await _send<rtapi.ChannelMessageAck>(rtapi.Envelope(
+        channelMessageUpdate: rtapi.ChannelMessageUpdate(
       channelId: channelId,
       messageId: messageId,
       content: jsonEncode(content),

--- a/nakama/test/grpc/authentication_test.dart
+++ b/nakama/test/grpc/authentication_test.dart
@@ -1,7 +1,6 @@
 import 'package:faker/faker.dart';
 import 'package:nakama/nakama.dart';
-import 'package:test/expect.dart';
-import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
 
 import '../config.dart';
 

--- a/nakama/test/grpc/leaderboard_test.dart
+++ b/nakama/test/grpc/leaderboard_test.dart
@@ -2,8 +2,7 @@ import 'dart:convert';
 
 import 'package:faker/faker.dart';
 import 'package:nakama/nakama.dart';
-import 'package:test/expect.dart';
-import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
 
 import '../config.dart';
 

--- a/nakama/test/integrity_test.dart
+++ b/nakama/test/integrity_test.dart
@@ -1,5 +1,4 @@
-import 'package:nakama/src/enum/friendship_state.dart';
-import 'package:nakama/src/enum/group_membership_states.dart';
+import 'package:nakama/nakama.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/nakama/test/rest/authentication_test.dart
+++ b/nakama/test/rest/authentication_test.dart
@@ -1,7 +1,6 @@
 import 'package:faker/faker.dart';
 import 'package:nakama/nakama.dart';
-import 'package:test/expect.dart';
-import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
 
 import '../config.dart';
 

--- a/nakama/test/rt/chat_test.dart
+++ b/nakama/test/rt/chat_test.dart
@@ -2,8 +2,7 @@ import 'dart:convert';
 
 import 'package:faker/faker.dart';
 import 'package:nakama/nakama.dart';
-import 'package:test/expect.dart';
-import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
 
 import '../config.dart';
 

--- a/satori/lib/src/models/event.dart
+++ b/satori/lib/src/models/event.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'event.freezed.dart';
 part 'event.g.dart';

--- a/satori/lib/src/models/experiment.dart
+++ b/satori/lib/src/models/experiment.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'experiment.freezed.dart';
 part 'experiment.g.dart';

--- a/satori/lib/src/models/flag.dart
+++ b/satori/lib/src/models/flag.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'flag.freezed.dart';
 part 'flag.g.dart';

--- a/satori/lib/src/models/live_event.dart
+++ b/satori/lib/src/models/live_event.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'live_event.freezed.dart';
 part 'live_event.g.dart';

--- a/satori/lib/src/models/properties.dart
+++ b/satori/lib/src/models/properties.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'properties.freezed.dart';
 part 'properties.g.dart';

--- a/satori/lib/src/models/session.dart
+++ b/satori/lib/src/models/session.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
+
+import '../rest/satori.swagger.dart';
 
 part 'session.freezed.dart';
 

--- a/satori/lib/src/satori_client/satori_api_client.dart
+++ b/satori/lib/src/satori_client/satori_api_client.dart
@@ -1,14 +1,15 @@
 import 'dart:convert';
 
 import 'package:chopper/chopper.dart';
-import 'package:satori/src/models/event.dart';
-import 'package:satori/src/models/experiment.dart';
-import 'package:satori/src/models/flag.dart';
-import 'package:satori/src/models/live_event.dart';
-import 'package:satori/src/models/properties.dart';
-import 'package:satori/src/models/session.dart';
-import 'package:satori/src/rest/satori.swagger.dart';
-import 'package:satori/src/satori_client/satori_client.dart';
+
+import '../models/event.dart';
+import '../models/experiment.dart';
+import '../models/flag.dart';
+import '../models/live_event.dart';
+import '../models/properties.dart';
+import '../models/session.dart';
+import '../rest/satori.swagger.dart';
+import 'satori_client.dart';
 
 /// A REST client to interact with the API in Satori.
 class SatoriRestApiClient extends SatoriBaseClient {

--- a/satori/lib/src/satori_client/satori_client.dart
+++ b/satori/lib/src/satori_client/satori_client.dart
@@ -1,9 +1,9 @@
-import 'package:satori/src/models/event.dart';
-import 'package:satori/src/models/experiment.dart';
-import 'package:satori/src/models/flag.dart';
-import 'package:satori/src/models/live_event.dart';
-import 'package:satori/src/models/properties.dart';
-import 'package:satori/src/models/session.dart';
+import '../models/event.dart';
+import '../models/experiment.dart';
+import '../models/flag.dart';
+import '../models/live_event.dart';
+import '../models/properties.dart';
+import '../models/session.dart';
 
 /// An interface for the Satori client.
 abstract class SatoriBaseClient {

--- a/satori/lib/src/satori_client/stub/api_client.dart
+++ b/satori/lib/src/satori_client/stub/api_client.dart
@@ -1,5 +1,5 @@
-import 'package:satori/src/satori_client/satori_api_client.dart';
-import 'package:satori/src/satori_client/satori_client.dart';
+import '../satori_api_client.dart';
+import '../satori_client.dart';
 
 SatoriBaseClient getSatoriClient({
   String host = '127.0.0.1',

--- a/satori/lib/src/satori_client/stub/satori_client_stub.dart
+++ b/satori/lib/src/satori_client/stub/satori_client_stub.dart
@@ -1,4 +1,4 @@
-import 'package:satori/src/satori_client/satori_client.dart';
+import '../satori_client.dart';
 
 SatoriBaseClient getSatoriClient({
   String? host = '127.0.0.1',


### PR DESCRIPTION
Relative imports are shorter, make it obvious which imports are from within the package, and how close the current library is relative to the imported libraries.

We don't want to import the public library from within the package, and instead directly import from libraries within the package to make the dependencies of the library obvious.