### PR TITLE
Support retrying requests

### DIFF
--- a/nakama/lib/nakama.dart
+++ b/nakama/lib/nakama.dart
@@ -41,4 +41,5 @@ export 'src/models/storage_permission.dart'
     show StorageReadPermission, StorageWritePermission;
 export 'src/models/tournament.dart'
     show Tournament, TournamentList, TournamentRecordList;
+export 'src/retry_policy.dart' show RetryPolicy, ExponentialBackoff;
 export 'src/socket.dart' show Socket;

--- a/nakama/lib/src/client_io.dart
+++ b/nakama/lib/src/client_io.dart
@@ -1,5 +1,6 @@
 import 'client.dart';
 import 'grpc_client.dart';
+import 'retry_policy.dart';
 
 Client createClient({
   required String host,
@@ -7,6 +8,7 @@ Client createClient({
   required int grpcPort,
   required bool ssl,
   required String serverKey,
+  required RetryPolicy retryPolicy,
 }) =>
     GrpcClient(
       host: host,
@@ -14,4 +16,5 @@ Client createClient({
       grpcPort: grpcPort,
       ssl: ssl,
       serverKey: serverKey,
+      retryPolicy: retryPolicy,
     );

--- a/nakama/lib/src/client_stub.dart
+++ b/nakama/lib/src/client_stub.dart
@@ -1,4 +1,5 @@
 import 'client.dart';
+import 'retry_policy.dart';
 
 Client createClient({
   required String host,
@@ -6,6 +7,7 @@ Client createClient({
   required int grpcPort,
   required bool ssl,
   required String serverKey,
+  required RetryPolicy retryPolicy,
 }) =>
     throw UnsupportedError(
       'Nakama is not supported outside IO/JS runtime.',

--- a/nakama/lib/src/client_web.dart
+++ b/nakama/lib/src/client_web.dart
@@ -1,5 +1,6 @@
 import 'client.dart';
 import 'rest_client.dart';
+import 'retry_policy.dart';
 
 Client createClient({
   required String host,
@@ -7,6 +8,7 @@ Client createClient({
   required int grpcPort,
   required bool ssl,
   required String serverKey,
+  required RetryPolicy retryPolicy,
 }) =>
     RestClient(
       host: host,
@@ -14,4 +16,5 @@ Client createClient({
       grpcPort: grpcPort,
       ssl: ssl,
       serverKey: serverKey,
+      retryPolicy: retryPolicy,
     );

--- a/nakama/lib/src/grpc_client.dart
+++ b/nakama/lib/src/grpc_client.dart
@@ -20,6 +20,7 @@ import 'models/notification.dart';
 import 'models/session.dart';
 import 'models/storage.dart';
 import 'models/tournament.dart';
+import 'retry_policy.dart';
 import 'socket.dart';
 
 class _AuthenticationInterceptor extends ClientInterceptor {
@@ -58,6 +59,7 @@ final class GrpcClient extends ClientBase {
     required int grpcPort,
     required bool ssl,
     required String serverKey,
+    required RetryPolicy retryPolicy,
   }) {
     final channel = ClientChannel(
       host,
@@ -80,6 +82,7 @@ final class GrpcClient extends ClientBase {
       grpcPort: grpcPort,
       ssl: ssl,
       serverKey: serverKey,
+      retryPolicy: retryPolicy,
       channel: channel,
       client: client,
       authenticationInterceptor: authenticationInterceptor,
@@ -92,6 +95,7 @@ final class GrpcClient extends ClientBase {
     required super.grpcPort,
     required super.ssl,
     required super.serverKey,
+    required super.retryPolicy,
     required ClientChannelBase channel,
     required NakamaClient client,
     required _AuthenticationInterceptor authenticationInterceptor,
@@ -127,6 +131,11 @@ final class GrpcClient extends ClientBase {
       onDisconnect: onDisconnect,
       onError: onError,
     );
+  }
+
+  @override
+  Future<void> performHealthcheck() async {
+    await _client.healthcheck(api.Empty());
   }
 
   @override

--- a/nakama/lib/src/models/error.dart
+++ b/nakama/lib/src/models/error.dart
@@ -170,12 +170,9 @@ final class ErrorCode {
 }
 
 /// An error returned by the Nakama server.
-class NakamaError implements Exception {
+final class NakamaError implements Exception {
   /// Creates a new [NakamaError] with the given [code] and [message].
-  NakamaError({
-    required this.code,
-    required this.message,
-  });
+  NakamaError({required this.code, this.message});
 
   /// The error code returned by the server.
   final ErrorCode code;

--- a/nakama/lib/src/retry_policy.dart
+++ b/nakama/lib/src/retry_policy.dart
@@ -1,0 +1,156 @@
+import 'dart:math';
+
+import 'package:meta/meta.dart';
+
+import 'models/error.dart';
+
+/// Retry policy for retrying requests.
+///
+/// To disable retries, set [Client.retryPolicy] to [RetryPolicy.noRetries].
+abstract interface class RetryPolicy {
+  /// A retry policy that does not retry requests.
+  static const noRetries = _NoRetires();
+
+  /// Returns wether the request should be retried.
+  ///
+  /// If this method returns `true`, the request will be retried immediately
+  /// after the [Future] returned by this method completes.
+  ///
+  /// [attempt] is the number of attempts that have been made so far, starting
+  /// at 1 with the first attempt.
+  ///
+  /// [errorCode] is the error code of the last response.
+  Future<bool> shouldRetry(int attempt, ErrorCode errorCode);
+}
+
+final class _NoRetires implements RetryPolicy {
+  const _NoRetires();
+
+  @override
+  Future<bool> shouldRetry(int attempt, ErrorCode errorCode) async => false;
+}
+
+@visibleForTesting
+Random exponentialBackoffRandom = Random();
+
+/// Retry policy that implements the
+/// [gRPC exponential backoff retry policy](https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-capabilities).
+final class ExponentialBackoff implements RetryPolicy {
+  /// Creates a new retry policy.
+  ExponentialBackoff({
+    this.maxAttempts = defaultMaxAttempts,
+    this.initialBackoff = defaultInitialBackoff,
+    this.maxBackoff = defaultMaxBackoff,
+    this.backoffMultiplier = defaultBackoffMultiplier,
+    this.retryableErrorCodes = defaultRetryableErrorCodes,
+  }) {
+    if (maxAttempts < 1) {
+      throw ArgumentError.value(
+        maxAttempts,
+        'maxAttempts',
+        'must be at least 1',
+      );
+    }
+    if (initialBackoff <= Duration.zero) {
+      throw ArgumentError.value(
+        initialBackoff,
+        'initialBackoff',
+        'must be greater than zero',
+      );
+    }
+    if (maxBackoff <= Duration.zero) {
+      throw ArgumentError.value(
+        maxBackoff,
+        'maxBackoff',
+        'must be greater than zero',
+      );
+    }
+    if (backoffMultiplier <= 0) {
+      throw ArgumentError.value(
+        backoffMultiplier,
+        'backoffMultiplier',
+        'must be greater than zero',
+      );
+    }
+    if (retryableErrorCodes.isEmpty) {
+      throw ArgumentError.value(
+        retryableErrorCodes,
+        'retryableErrorCodes',
+        'must not be empty',
+      );
+    }
+  }
+
+  const ExponentialBackoff._({
+    required this.maxAttempts,
+    required this.initialBackoff,
+    required this.maxBackoff,
+    required this.backoffMultiplier,
+    required this.retryableErrorCodes,
+  });
+
+  /// The default for [maxAttempts].
+  static const defaultMaxAttempts = 5;
+
+  /// The default for [initialBackoff].
+  static const defaultInitialBackoff = Duration(milliseconds: 100);
+
+  /// The default for [maxBackoff].
+  static const defaultMaxBackoff = Duration(seconds: 1);
+
+  /// The default for [backoffMultiplier].
+  static const defaultBackoffMultiplier = 2.0;
+
+  /// The default for [retryableErrorCodes].
+  static const defaultRetryableErrorCodes = [
+    ErrorCode.internal,
+    ErrorCode.unavailable,
+  ];
+
+  /// The policy using [defaultMaxAttempts], [defaultInitialBackoff],
+  /// [defaultMaxBackoff], [defaultBackoffMultiplier], and
+  /// [defaultRetryableErrorCodes].
+  static const defaultPolicy = ExponentialBackoff._(
+    maxAttempts: defaultMaxAttempts,
+    initialBackoff: defaultInitialBackoff,
+    maxBackoff: defaultMaxBackoff,
+    backoffMultiplier: defaultBackoffMultiplier,
+    retryableErrorCodes: defaultRetryableErrorCodes,
+  );
+
+  /// The maximum number of retries to make.
+  final int maxAttempts;
+
+  /// The initial backoff duration.
+  final Duration initialBackoff;
+
+  /// The maximum backoff duration.
+  final Duration maxBackoff;
+
+  /// The backoff multiplier.
+  final double backoffMultiplier;
+
+  /// The error codes that should be retried.
+  final List<ErrorCode> retryableErrorCodes;
+
+  @override
+  Future<bool> shouldRetry(int attempt, ErrorCode errorCode) async {
+    assert(attempt >= 1);
+    if (attempt < maxAttempts && retryableErrorCodes.contains(errorCode)) {
+      await Future.delayed(backoff(attempt));
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// The backoff duration for the given attempt.
+  Duration backoff(int attempt) {
+    assert(attempt >= 1);
+    var duration = initialBackoff * pow(backoffMultiplier, attempt - 1);
+    if (duration > maxBackoff) {
+      duration = maxBackoff;
+    }
+    return duration * exponentialBackoffRandom.nextDouble();
+  }
+}

--- a/nakama/test/client/client_base_test.dart
+++ b/nakama/test/client/client_base_test.dart
@@ -1,0 +1,52 @@
+import 'package:nakama/nakama.dart';
+import 'package:nakama/src/client.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  test('uses retry policy to retry failed requests', () async {
+    final client = TestClient(
+      retryPolicy: TestRetryPolicy(expectAsync2(
+        (attempt, code) {
+          expect(code, ErrorCode.unavailable);
+          return attempt < 3;
+        },
+        count: 3,
+      )),
+    );
+
+    await expectLater(
+      client.healthcheck(),
+      throwsA(isA<NakamaError>().havingCode(ErrorCode.unavailable)),
+    );
+  });
+}
+
+class TestRetryPolicy implements RetryPolicy {
+  TestRetryPolicy(this._shouldRetry);
+
+  final bool Function(int attempt, ErrorCode errorCode) _shouldRetry;
+
+  @override
+  Future<bool> shouldRetry(int attempt, ErrorCode errorCode) async =>
+      _shouldRetry(attempt, errorCode);
+}
+
+final class TestClient extends ClientBase {
+  TestClient({required super.retryPolicy})
+      : super(
+          host: '',
+          httpPort: 0,
+          grpcPort: 0,
+          ssl: false,
+          serverKey: '',
+        );
+
+  @override
+  NakamaError? translateException(Exception exception) =>
+      NakamaError(code: ErrorCode.unavailable);
+
+  @override
+  void noSuchMethod(Invocation invocation) => throw Exception();
+}

--- a/nakama/test/client/client_test.dart
+++ b/nakama/test/client/client_test.dart
@@ -1,0 +1,27 @@
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  clientTests((helper) {
+    clientTest(
+      'connecting to unavailable server results in ErrorCode.unavailable',
+      () async {
+        final client = helper.createClient(toAvailableServer: false);
+        await expectLater(
+          client.healthcheck(),
+          throwsA(
+            isA<NakamaError>()
+                .havingCode(ErrorCode.unavailable)
+                .havingMessage(contains('Connection refused')),
+          ),
+        );
+      },
+    );
+
+    clientTest('healthcheck', () async {
+      await helper.createClient().healthcheck();
+    });
+  });
+}

--- a/nakama/test/client/retry_policy_test.dart
+++ b/nakama/test/client/retry_policy_test.dart
@@ -1,0 +1,88 @@
+import 'dart:math';
+
+import 'package:nakama/nakama.dart';
+import 'package:nakama/src/retry_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('noRetries policy never retries request', () async {
+    await expectLater(
+      RetryPolicy.noRetries.shouldRetry(1, ErrorCode.unavailable),
+      completion(false),
+    );
+  });
+
+  group('ExponentialBackoff', () {
+    test('validates parameters', () {
+      expect(
+        () => ExponentialBackoff(maxAttempts: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => ExponentialBackoff(initialBackoff: Duration.zero),
+        throwsArgumentError,
+      );
+      expect(
+        () => ExponentialBackoff(maxBackoff: Duration.zero),
+        throwsArgumentError,
+      );
+      expect(
+        () => ExponentialBackoff(backoffMultiplier: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => ExponentialBackoff(retryableErrorCodes: []),
+        throwsArgumentError,
+      );
+    });
+
+    test('limits max number of attempts', () async {
+      final policy = ExponentialBackoff(maxAttempts: 3);
+      expect(await policy.shouldRetry(1, ErrorCode.unavailable), isTrue);
+      expect(await policy.shouldRetry(2, ErrorCode.unavailable), isTrue);
+      expect(await policy.shouldRetry(3, ErrorCode.unavailable), isFalse);
+    });
+
+    test('checks if error code is retryable', () async {
+      final policy =
+          ExponentialBackoff(retryableErrorCodes: [ErrorCode.internal]);
+      expect(await policy.shouldRetry(1, ErrorCode.internal), isTrue);
+      expect(await policy.shouldRetry(1, ErrorCode.unavailable), isFalse);
+    });
+
+    test('limits backoff', () {
+      final policy = ExponentialBackoff(
+        initialBackoff: const Duration(milliseconds: 200),
+        maxBackoff: const Duration(milliseconds: 100),
+      );
+
+      for (var i = 1; i <= 100; i++) {
+        expect(policy.backoff(i) < const Duration(milliseconds: 100), isTrue);
+      }
+    });
+
+    test('randomizes backoff', () async {
+      exponentialBackoffRandom = Random(0);
+      addTearDown(() => exponentialBackoffRandom = Random());
+      final policy = ExponentialBackoff();
+
+      expect(
+        [
+          for (var i = 1; i <= 10; i++) policy.backoff(i),
+        ],
+        [
+          82551,
+          177263,
+          169889,
+          571193,
+          850237,
+          780342,
+          955731,
+          942536,
+          595523,
+          138063
+        ].map((ms) => Duration(microseconds: ms)),
+      );
+    });
+  });
+}

--- a/nakama/test/helpers.dart
+++ b/nakama/test/helpers.dart
@@ -26,10 +26,18 @@ class TestHelper {
     return client;
   });
 
-  Client createClient({bool tearDown = true}) {
+  Client createClient({bool tearDown = true, bool toAvailableServer = true}) {
     final client = switch (clientType) {
-      ClientType.rest => Client.rest(host: testHost),
-      ClientType.grpc => Client.grpc(host: testHost),
+      ClientType.rest => Client.rest(
+          host: testHost,
+          httpPort: toAvailableServer ? Client.defaultHttpPort : 1,
+          grpcPort: toAvailableServer ? Client.defaultGrpcPort : 1,
+        ),
+      ClientType.grpc => Client.grpc(
+          host: testHost,
+          httpPort: toAvailableServer ? Client.defaultHttpPort : 1,
+          grpcPort: toAvailableServer ? Client.defaultGrpcPort : 1,
+        ),
     };
 
     if (tearDown) {


### PR DESCRIPTION
API changes:

- Added `Client.healtcheck`
- Added `RetryPolicy` and `ExponentialBackoff`
- Added `Client.retryPolicy`
- Handle connection errors in REST client and report them as `NakamaError` with `ErrorCode.unavailable`